### PR TITLE
Fixed contract name

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ If you are using Hardhat:
     // change to your vault implementation
     import "./Basic4626Impl.sol";
 
-    contract Crytic4626Harness is CryticERC4626PropertyTests {
+    contract CryticERC4626Harness is CryticERC4626PropertyTests {
         constructor () {
             TestERC20Token _asset = new TestERC20Token("Test Token", "TT", 18);
             Basic4626Impl _vault = new Basic4626Impl(_asset);


### PR DESCRIPTION
The contract name doesn't match the `echidna-test` command below. Leads to an ambiguous error `echidna-test: Given contract "Crytic4626Harness" not found in given file`. Changing the contract name to `CryticERC4626Harness` fixes this.