### PR TITLE
Add link to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - [Clamping](#clamping)
 - [HEVM cheat codes support](#hevm-cheat-codes-support)
   - [Usage example](#usage-example)
+- [How to contribute to this repo?](#how-to-contribute-to-this-repo)
 
 
 # Properties
@@ -416,3 +417,6 @@ contract TestProperties {
 }
 
 ```
+
+# How to contribute to this repo?
+Contributions are welcome! You can read more about the contribution guidelines and directory structure in the [CONTRIBUTING.md](CONTRIBUTING.md) file. 


### PR DESCRIPTION
As of now, there is no mention of the `CONTRIBUTING.md` file in the main repo `README.md`. 

This PR:
- adds a short section at the bottom with the link to the `CONTRIBUTING.md` file