### PR TITLE
Remove try/catch from verify_depositProperties

### DIFF
--- a/contracts/ERC4626/properties/FunctionalAccountingProps.sol
+++ b/contracts/ERC4626/properties/FunctionalAccountingProps.sol
@@ -16,9 +16,7 @@ contract CryticERC4626FunctionalAccounting is CryticERC4626PropertyBase {
         (, uint256 receiverSharesBeforeDeposit) = measureAddressHoldings(receiver, "receiver", "before deposit");
 
         uint256 sharesExpected = vault.previewDeposit(tokens);
-        uint256 sharesMinted;
-        try vault.deposit(tokens,receiver) returns (uint256 sharesMinted2) {sharesMinted = sharesMinted2;} catch {assert(false);}
-        //uint256 sharesMinted = vault.deposit(tokens, receiver);
+        uint256 sharesMinted = vault.deposit(tokens, receiver);
         assertGte(sharesMinted, sharesExpected, "deposit() must always mint greater than or equal to the shares predicted by previewDeposit()");
 
         (uint256 senderAssetsAfterDeposit,) = measureAddressHoldings(sender, "sender", "after deposit");


### PR DESCRIPTION
Remove `try/catch` block around `vault.deposit` from function `verify_depositProperties`. 

The previous implementation seemed to be a work-in-progress piece of code left out in this contract, as the logic is different from the other functions: `verify_mintProperties`, `verify_redeemProperties`, and `verify_withdrawProperties`.

Moreover, the previous implementation would prevent echidna from successfully completing when deposits reverted due to an invalid parameter. For example, in case an ERC4264 vault requires a minimum deposit amount. This might be the case when the vault tries to address the issue `H-01 Vault deposits can be front-run and user funds stolen` from [OpenZeppelin ERC4626 Tokenized Vault Audit](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/audits/2022-10-ERC4626.pdf) by reverting when `assets` is zero.