### PR TITLE
Update readme and configs to be consistent with the latest echidna version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -32,7 +32,7 @@ body:
     type: textarea
   - attributes:
       label: "Echidna version:"
-      description: "Run `echidna-test --version`"
+      description: "Run `echidna --version`"
     id: version
     type: textarea
     validations:

--- a/PROPERTIES.md
+++ b/PROPERTIES.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This file lists all the currently implemented Echidna property tests for ERC20, ERC4626 and ABDKMath64x64. For each property, there is a permalink to the file implementing it in the repository and a small description of the invariant tested.
+This file lists all the currently implemented Echidna property tests for ERC20, ERC721, ERC4626 and ABDKMath64x64. For each property, there is a permalink to the file implementing it in the repository and a small description of the invariant tested.
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ sender: ["0x10000", "0x20000", "0x30000"]
 If you're using external testing, you will also need to specify:
 
 ```yaml
-multi-abi: true
+allContracts: true
 ```
 
 To perform more than one test, save the files with a descriptive path, to identify what test each file or corpus belongs to. For these examples, we use `tests/crytic/erc20/echidna-internal.yaml` and `tests/crytic/erc20/echidna-external.yaml` for the Echidna tests for ERC20. We recommended to modify the `corpusDir` for external tests accordingly.
@@ -142,8 +142,8 @@ The above configuration will start Echidna in assertion mode. Contract will be d
 
 Run Echidna:
 
-- For internal testing: `echidna-test . --contract CryticERC20InternalHarness --config tests/crytic/erc20/echidna-internal.yaml`
-- For external testing: `echidna-test . --contract CryticERC20ExternalHarness --config tests/crytic/erc20/echidna-external.yaml`
+- For internal testing: `echidna . --contract CryticERC20InternalHarness --config tests/crytic/erc20/echidna-internal.yaml`
+- For external testing: `echidna . --contract CryticERC20ExternalHarness --config tests/crytic/erc20/echidna-external.yaml`
 
 Finally, inspect the coverage report in `tests/crytic/erc20/echidna-corpus-internal` or `tests/crytic/erc20/echidna-corpus-external` when it finishes.
 
@@ -152,7 +152,7 @@ Finally, inspect the coverage report in `tests/crytic/erc20/echidna-corpus-inter
 If the token under test is compliant and no properties will fail during fuzzing, the Echidna output should be similar to the screen below:
 
 ```
-$ echidna-test . --contract CryticERC20InternalHarness --config tests/echidna.config.yaml
+$ echidna . --contract CryticERC20InternalHarness --config tests/echidna.config.yaml
 Loaded total of 23 transactions from corpus/coverage
 Analyzing contract: contracts/ERC20/CryticERC20InternalHarness.sol:CryticERC20InternalHarness
 name():  passed! 🎉
@@ -177,7 +177,7 @@ function approve(address spender, uint256 amount) public virtual override(ERC20)
 In this case, the Echidna output should be similar to the screen below, notice that all functions that rely on `approve()` to work correctly will have their assertions broken, and will report the situation.
 
 ```
-$ echidna-test . --contract CryticERC20ExternalHarness --config tests/echidna.config.yaml
+$ echidna . --contract CryticERC20ExternalHarness --config tests/echidna.config.yaml
 Loaded total of 25 transactions from corpus/coverage
 Analyzing contract: contracts/ERC20/CryticERC20ExternalHarness.sol:CryticERC20ExternalHarness
 name():  passed! 🎉
@@ -260,7 +260,7 @@ sender: ["0x10000", "0x20000", "0x30000"]
 If you're using external testing, you will also need to specify:
 
 ```yaml
-multi-abi: true
+allContracts: true
 ```
 
 To perform more than one test, save the files with a descriptive path, to identify what test each file or corpus belongs to. For these examples, we use `tests/crytic/erc721/echidna-internal.yaml` and `tests/crytic/erc721/echidna-external.yaml` for the Echidna tests for ERC721. We recommended to modify the `corpusDir` for external tests accordingly.
@@ -269,8 +269,8 @@ The above configuration will start Echidna in assertion mode. Contract will be d
 
 #### Run
 Run Echidna: 
-- For internal testing: `echidna-test . --contract CryticERC721InternalHarness --config tests/crytic/erc721/echidna-internal.yaml` 
-- For external testing: `echidna-test . --contract CryticERC721ExternalHarness --config tests/crytic/erc721/echidna-external.yaml` 
+- For internal testing: `echidna . --contract CryticERC721InternalHarness --config tests/crytic/erc721/echidna-internal.yaml` 
+- For external testing: `echidna . --contract CryticERC721ExternalHarness --config tests/crytic/erc721/echidna-external.yaml` 
   
 Finally, inspect the coverage report in `tests/crytic/erc721/echidna-corpus-internal` or `tests/crytic/erc721/echidna-corpus-external` when it finishes.
 
@@ -278,7 +278,7 @@ Finally, inspect the coverage report in `tests/crytic/erc721/echidna-corpus-inte
 
 If the token under test is compliant and no properties will fail during fuzzing, the Echidna output should be similar to the screen below:
 ```
-$ echidna-test . --contract CryticERC721InternalHarness --config tests/echidna.config.yaml 
+$ echidna . --contract CryticERC721InternalHarness --config tests/echidna.config.yaml 
 Loaded total of 23 transactions from corpus/coverage
 Analyzing contract: contracts/ERC721/CryticERC721InternalHarness.sol:CryticERC721InternalHarness
 name():  passed! 🎉
@@ -300,7 +300,7 @@ function balanceOf(address owner) public view virtual override returns (uint256)
 
 In this case, the Echidna output should be similar to the screen below, notice that all functions that rely on `balanceOf()` to work correctly will have their assertions broken, and will report the situation.
 ```
-$ echidna-test . --contract CryticERC721ExternalHarness --config tests/echidna.config.yaml
+$ echidna . --contract CryticERC721ExternalHarness --config tests/echidna.config.yaml
 Loaded total of 25 transactions from corpus/coverage
 Analyzing contract: contracts/ERC721/CryticERC721ExternalHarness.sol:CryticERC721ExternalHarness
 name():  passed! 🎉
@@ -377,7 +377,7 @@ sender: ["0x10000"]
 
 #### Run
 
-Run the test suite using `echidna-test . --contract CryticERC4626Harness --config tests/echidna.config.yaml` and inspect the coverage report in `tests/echidna-corpus` when it finishes.
+Run the test suite using `echidna . --contract CryticERC4626Harness --config tests/echidna.config.yaml` and inspect the coverage report in `tests/echidna-corpus` when it finishes.
 
 Example repositories are available for [Hardhat](tests/ERC4626/hardhat) and [Foundry](tests/ERC4626/foundry).
 
@@ -412,7 +412,7 @@ contract CryticABDKMath64x64Harness is CryticABDKMath64x64PropertyTests {
 
 #### Run
 
-Run the test suite using `echidna-test . --contract CryticABDKMath64x64Harness --seq-len 1 --test-mode assertion --corpus-dir tests/echidna-corpus` and inspect the coverage report in `tests/echidna-corpus` when it finishes.
+Run the test suite using `echidna . --contract CryticABDKMath64x64Harness --seq-len 1 --test-mode assertion --corpus-dir tests/echidna-corpus` and inspect the coverage report in `tests/echidna-corpus` when it finishes.
 
 ## Additional resources
 

--- a/contracts/ERC20/external/echidna.config.yaml
+++ b/contracts/ERC20/external/echidna.config.yaml
@@ -1,5 +1,5 @@
 coverage: true
-multi-abi: true
+allContracts: true
 corpusDir: "corpus"
 testMode: assertion
 testLimit: 100000

--- a/contracts/ERC4626/README.md
+++ b/contracts/ERC4626/README.md
@@ -50,38 +50,38 @@ Before doing any development, run `forge install` to get dependencies sorted out
 
 Running tests(used to validate the properties are working correctly):
 
-`echidna-test ./contracts/ERC4626/test/rounding/BadConvertToAssetsRounding.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
+`echidna ./contracts/ERC4626/test/rounding/BadConvertToAssetsRounding.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
 Should cause these properties to fail:
 
 - verify_previewRedeemRoundingDirection
 - verify_redeemRoundingDirection
 - verify_convertToAssetsRoundingDirection
 
-`echidna-test ./contracts/ERC4626/test/rounding/BadConvertToSharesRounding.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
+`echidna ./contracts/ERC4626/test/rounding/BadConvertToSharesRounding.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
 Should cause these properties to fail:
 
 - verify_convertToSharesRoundingDirection
 - verify_previewDepositRoundingDirection
 - verify_depositRoundingDirection
 
-`echidna-test ./contracts/ERC4626/test/rounding/BadPreviewMintRounding.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
+`echidna ./contracts/ERC4626/test/rounding/BadPreviewMintRounding.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
 Should cause these properties to fail:
 
 - verify_previewMintRoundingDirection
 - verify_mintRoundingDirection
 
-`echidna-test ./contracts/ERC4626/test/rounding/BadPreviewWithdrawRounding.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
+`echidna ./contracts/ERC4626/test/rounding/BadPreviewWithdrawRounding.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
 Should cause these properties to fail:
 
 - verify_previewWithdrawRoundingDirection
 - verify_withdrawRoundingDirection
 
-`echidna-test ./contracts/ERC4626/test/security/BadShareInflation.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
+`echidna ./contracts/ERC4626/test/security/BadShareInflation.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
 Should cause these properties to fail:
 
 - verify_sharePriceInflationAttack
 
-`echidna-test ./contracts/ERC4626/test/usingApproval/BadAllowanceUpdate.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
+`echidna ./contracts/ERC4626/test/usingApproval/BadAllowanceUpdate.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
 Should cause these properties to fail:
 
 - verify_redeemViaApprovalProxy
@@ -91,7 +91,7 @@ Should cause these properties to fail:
 
 Run property tests against vanilla solmate:
 
-`echidna-test ./contracts/ERC4626/test/Solmate4626.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
+`echidna ./contracts/ERC4626/test/Solmate4626.sol --contract TestHarness --config ./contracts/ERC4626/test/echidna.config.yaml`
 
 [EIP-4626 Spec](https://eips.ethereum.org/EIPS/eip-4626)
 

--- a/contracts/ERC721/README.md
+++ b/contracts/ERC721/README.md
@@ -14,12 +14,12 @@
 ## Consuming
 
 ### Initial setup
-To use these properties to test a given vault implementation, see the readme in the project root.
+To use these properties to test a given ERC721 implementation, see the readme in the project root.
 
 ### Adding internal test methods to an ERC721
 Some properties of the ERC721 spec cannot be tested externally because testing them requires interactions between the test suite & functionality that is not defined in the spec. 
 
-To compensate for this limitation, a vault under test may optionally implement a set of methods that allow such properties to be tested. See [IERC721Internal](util/IERC721Internal.sol) for the list of methods.
+To compensate for this limitation, a contract under test may optionally implement a set of methods that allow such properties to be tested. See [IERC721Internal](util/IERC721Internal.sol) for the list of methods.
 
 These methods should be added to the ERC721 contract by a derived, test-environment-only contract to minimize changes to the production contract.
 

--- a/tests/ERC20/foundry/echidna-config-ext.yaml
+++ b/tests/ERC20/foundry/echidna-config-ext.yaml
@@ -3,4 +3,4 @@ testMode: assertion
 testLimit: 10000
 deployer: "0x10000"
 sender: ["0x10000", "0x20000", "0x30000"]
-multi-abi: true
+allContracts: true

--- a/tests/ERC20/hardhat/tests/echidna-config-ext.yaml
+++ b/tests/ERC20/hardhat/tests/echidna-config-ext.yaml
@@ -3,4 +3,4 @@ testMode: assertion
 testLimit: 10000
 deployer: "0x10000"
 sender: ["0x10000", "0x20000", "0x30000"]
-multi-abi: true
+allContracts: true

--- a/tests/ERC4626/foundry/README.md
+++ b/tests/ERC4626/foundry/README.md
@@ -24,4 +24,4 @@ Contract under test is `Basic4626Impl`, which inherits from solmate's ERC4626 mi
 
 Test harness is `CryticERC4626InternalHarness`
 
-To run tests, use `echidna-test . --contract CryticERC4626InternalHarness --config ./echidna.yaml`
+To run tests, use `echidna . --contract CryticERC4626InternalHarness --config ./echidna.yaml`

--- a/tests/ERC4626/hardhat/README.md
+++ b/tests/ERC4626/hardhat/README.md
@@ -24,4 +24,4 @@ Contract under test is `Basic4626Impl`, which inherits from solmate's ERC4626 mi
 
 Test harness is `Echidna4626Harness`
 
-To run tests, use `npm run echidna4626` or `echidna-test . --contract Echidna4626Harness --config ./echidna.yaml`
+To run tests, use `npm run echidna4626` or `echidna . --contract Echidna4626Harness --config ./echidna.yaml`

--- a/tests/ERC4626/hardhat/package.json
+++ b/tests/ERC4626/hardhat/package.json
@@ -1,10 +1,10 @@
 {
-	"dependencies": {
-		"hardhat": "^2.12.4",
-		"solmate": "^6.6.1",
-		"@crytic/properties": "file:../../.."
-	},
-	"scripts": {
-		"echidna4626": "echidna . --contract Echidna4626Harness --config ./echidna.yaml"
-	}
+  "dependencies": {
+    "hardhat": "^2.12.4",
+    "solmate": "^6.6.1",
+    "@crytic/properties": "file:../../.."
+  },
+  "scripts": {
+    "echidna4626": "echidna . --contract Echidna4626Harness --config ./echidna.yaml"
+  }
 }

--- a/tests/ERC4626/hardhat/package.json
+++ b/tests/ERC4626/hardhat/package.json
@@ -1,10 +1,10 @@
 {
-  "dependencies": {
-    "hardhat": "^2.12.4",
-    "solmate": "^6.6.1",
-    "@crytic/properties": "file:../../.."
-  },
-  "scripts": {
-    "echidna4626": "echidna-test . --contract Echidna4626Harness --config ./echidna.yaml"
-  }
+	"dependencies": {
+		"hardhat": "^2.12.4",
+		"solmate": "^6.6.1",
+		"@crytic/properties": "file:../../.."
+	},
+	"scripts": {
+		"echidna4626": "echidna . --contract Echidna4626Harness --config ./echidna.yaml"
+	}
 }

--- a/tests/ERC721/foundry/echidna-config-ext.yaml
+++ b/tests/ERC721/foundry/echidna-config-ext.yaml
@@ -3,4 +3,4 @@ testMode: assertion
 testLimit: 10000
 deployer: "0x10000"
 sender: ["0x10000", "0x20000", "0x30000"]
-multi-abi: true
+allContracts: true

--- a/tests/ERC721/hardhat/tests/echidna-config-ext.yaml
+++ b/tests/ERC721/hardhat/tests/echidna-config-ext.yaml
@@ -3,5 +3,4 @@ testMode: assertion
 testLimit: 10000
 deployer: "0x10000"
 sender: ["0x10000", "0x20000", "0x30000"]
-multi-abi: true
-
+allContracts: true


### PR DESCRIPTION
Updated all the places that used `echidna-test` and `multi-abi `to the Echidna >=2.1.0 updated command and keyword.