### PR TITLE
Added ERC1155 properties

### DIFF
--- a/contracts/ERC1155/README.md
+++ b/contracts/ERC1155/README.md
@@ -1,0 +1,26 @@
+# Properties Tested
+
+### Basic properties
+- `balanceOf()` should revert on address zero
+- `balanceOfBatch` Works as expected
+- `safeTransferFrom()` should revert while transferring unapproved token
+- `safeTransferFrom()` correctly update balances
+- `safeTransferFrom()` should revert if `from` is the zero address
+- `safeTransferFrom()` should revert if `to` is the zero address
+- `safeTransferFrom()` to self should not break accounting
+- `safeBatchTransferFrom()` to self should not break accounting
+- `safeBatchTransferFrom()` correctly update balances
+- `safeTransferFrom()` should revert if receiver is a contract that does not implement onERC1155Received()
+- `safeBatchTransferFrom()` should revert if receiver is a contract that does not implement onERC1155Received()
+
+### Burnable properties 
+- `burn()` destroys token(s)
+- `burn()` destroys token(s) from approved address
+- `burnBatch()` destroys token(s)
+- `burnBatch()` destroys token(s) from approved address
+- cannot transfer a burned token
+- burned token(s) should not be transferrable when burned with burnBatch
+
+### Mintable properties
+- Should mint tokens and should increase balance
+- Should mint tokens in batch and should increase balance

--- a/contracts/ERC1155/external/ERC1155ExternalPropertyTests.sol
+++ b/contracts/ERC1155/external/ERC1155ExternalPropertyTests.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.8.13;
+
+import {CryticERC1155ExternalTestBase} from "./util/ERC1155ExternalTestBase.sol";
+import {CryticERC1155ExternalBasicProperties} from "./properties/ERC1155ExternalBasicProperties.sol";
+import {CryticERC1155ExternalBurnableProperties} from "./properties/ERC1155ExternalBurnableProperties.sol";
+import {CryticERC1155ExternalMintableProperties} from "./properties/ERC1155ExternalMintableProperties.sol";
+
+/// @notice Aggregator contract for various ERC1155 property tests. Inherit from this & echidna will test all properties at the same time.
+abstract contract CryticERC1155ExternalPropertyTests is CryticERC1155ExternalBasicProperties, CryticERC1155ExternalMintableProperties, CryticERC1155ExternalBurnableProperties  {
+    function _customMint(address to,uint id,uint amount) internal virtual override(CryticERC1155ExternalBasicProperties,CryticERC1155ExternalMintableProperties);
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal virtual override(CryticERC1155ExternalBasicProperties,CryticERC1155ExternalBurnableProperties,CryticERC1155ExternalMintableProperties);
+} 

--- a/contracts/ERC1155/external/properties/ERC1155ExternalBasicProperties.sol
+++ b/contracts/ERC1155/external/properties/ERC1155ExternalBasicProperties.sol
@@ -1,0 +1,212 @@
+pragma solidity ^0.8.13;
+
+import "../util/ERC1155ExternalTestBase.sol";
+import "../../../util/Hevm.sol";
+abstract contract CryticERC1155ExternalBasicProperties is CryticERC1155ExternalTestBase {
+    using Address for address;
+    mapping(uint256 => uint256) private idToAmount;
+    
+    ////////////////////////////////////////
+    // Properties
+
+    // Querying the balance of address(0) should throw
+    function test_ERC1155_external_balanceOfZeroAddressMustRevert() public virtual {
+        token.balanceOf(address(0),1);
+        assertWithMsg(false, "address(0) balance query should have reverted");
+    }
+
+    // balanceOfBatch works as expected
+    function test_ERC1155_external_balanceOfBatchWorksAsExpected(address[] memory targets,uint256[] memory ids,uint256[] memory amounts) public virtual{
+        // target,ids and amounts should have same length.
+        require(targets.length==ids.length);
+        
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(targets[i],ids[i])==0);
+        }
+        
+        // mint tokens to target
+        for (uint256 i = 0; i < ids.length; i++) {
+            _customMint(targets[i],ids[i],amounts[i]);
+        }
+        
+        // check balanceOfBatch gives same balances
+        uint256[] memory balances;
+        balances = token.balanceOfBatch(targets,ids);
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(balances[i]==token.balanceOf(targets[i],ids[i]), "Failed to return expected balance amount to for id");
+        }
+    }
+
+    // safeTransferFrom a token that the caller is not approved for should revert
+     function test_ERC1155_external_transferFromNotApproved(address target, uint256 id,uint256 amount) public virtual {
+        uint256 selfBalance = token.balanceOf(msg.sender,id);
+        require(selfBalance >= amount);        
+        require(target != address(this));
+        require(target != msg.sender);
+        
+        bool isApproved = token.isApprovedForAll(msg.sender,address(this));
+        require(!isApproved);
+
+        token.safeTransferFrom( msg.sender, target, id, amount,"");
+        assertWithMsg(false, "using safeTransferFrom without being approved should have reverted");
+    }
+
+    // safeTransferFrom correctly updates balance
+    function test_ERC1155_external_transferFromUpdatesBalance(address target, uint256 id,uint256 amount) public virtual {
+        uint256 selfBalanceBefore = token.balanceOf(msg.sender,id);
+        uint256 targetBalanceBefore = token.balanceOf(target,id);
+        require(selfBalanceBefore >= amount);
+        require(target != address(this));
+        require(target != msg.sender);
+        require(!Address.isContract(target));
+        hevm.prank(msg.sender);
+        try token.safeTransferFrom(msg.sender,target, id,amount,"") {
+        uint256 targetBalanceAfter = token.balanceOf(target,id);
+        uint256 selfBalanceAfter = token.balanceOf(msg.sender,id);
+            assertWithMsg(targetBalanceBefore+amount ==targetBalanceAfter, "Token balance of receiver not updated");
+            assertWithMsg(selfBalanceBefore-amount ==selfBalanceAfter, "Token balance target not updated");
+        } catch {
+            assertWithMsg(false, "safeTransferFrom unexpectedly reverted");
+        }
+    }
+
+    // transfer from zero address should revert/throw
+    function test_ERC1155_transferFromZeroAddress(uint256 id,uint256 amount) public virtual {
+        token.safeTransferFrom(address(0), msg.sender, id,amount,"");
+
+        assertWithMsg(false, "Transfer from zero address did not revert");
+    }
+
+    // Transfers to the zero address should revert
+        function test_ERC1155_external_transferFromToZeroAddress(uint256 id,uint256 amount) public virtual {
+        uint256 selfBalance = token.balanceOf(msg.sender,id);
+        require(selfBalance >= amount); 
+        
+        hevm.prank(msg.sender);
+        token.safeTransferFrom(msg.sender, address(0), id,amount,"");
+
+        assertWithMsg(false, "Transfer to zero address did not revert");
+    }
+
+    // Transfers to self should not break accounting
+     function test_ERC1155_external_transferFromSelf(uint256 id,uint256 amount) public virtual {
+        uint256 selfBalance = token.balanceOf(msg.sender,id);
+        require(selfBalance >= amount); 
+        
+        hevm.prank(msg.sender);
+
+        // transfer 1 token of id to self address from self address.
+        try token.safeTransferFrom(msg.sender, msg.sender, id,amount,"") {
+            assertWithMsg(selfBalance==token.balanceOf(msg.sender,id), "Self transfer breaks accounting");
+        } catch {
+            assertWithMsg(false, "safeTransferFrom unexpectedly reverted");
+        }
+    }
+
+    // Batch transfer to self should not break accounting
+    function test_ERC1155_external_safeBatchTransferFromSelf(uint256[] memory ids,uint256[] memory amounts) public virtual {
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            require(token.balanceOf(msg.sender,ids[i])==0);
+            idToAmount[ids[i]]+=amounts[i];
+        }
+
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // balance for ids should be similar to amounts
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+        
+        hevm.prank(msg.sender);
+        
+        // batch trasnfer tokens
+        token.safeBatchTransferFrom(msg.sender,msg.sender,ids,amounts,"");
+
+        // Balance should be same.
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(token.balanceOf(msg.sender,ids[i])==idToAmount[ids[i]], "Failed to mint expected balance amount to ids");
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+    }
+
+    // safeBatchTransferFrom correctly updates balance
+    function test_ERC1155_external_safeBatchTransferFrom(address target,uint256[] memory ids,uint256[] memory amounts) public virtual {
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        // sender's balance for ids should be equal to 0.
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(msg.sender,ids[i])==0);
+            idToAmount[ids[i]]+=amounts[i];
+        }
+
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+
+        // receiver's balance for ids should be 0
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(target,ids[i])==0);
+        }
+
+        hevm.prank(msg.sender);
+
+        // batch transfer tokens
+        token.safeBatchTransferFrom(msg.sender,target,ids,amounts,"");
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(token.balanceOf(msg.sender,ids[i])==0, "Failed to update sender's balance");
+        }
+
+        // Balance should have increased
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(token.balanceOf(target,ids[i])==idToAmount[ids[i]], "Failed to mint expected balance amount to target");
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+    }
+
+    // safeTransferFrom reverts if receiver does not implement the callback
+    function test_ERC1155_external_safeTransferFromRevertsOnNoncontractReceiver(uint256 id,uint256 amount) public virtual {
+        uint256 selfBalance = token.balanceOf(msg.sender,id);
+        require(selfBalance >= amount); 
+        
+        hevm.prank(msg.sender);
+        
+        token.safeTransferFrom(msg.sender, address(unsafeReceiver), id,amount,"");
+        assertWithMsg(false, "safeTransferFrom does not revert if receiver does not implement ERC1155.onERC1155Received");
+    }
+
+    // safeBatchTransferFrom reverts if receiver does not implement the callback
+    function test_ERC1155_exernal_safeBatchTransferFromRevertsOnNoncontractReceiver(uint256[] memory ids,uint256[] memory amounts) public virtual {
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(msg.sender,ids[i])>=amounts[i]);
+        }
+        
+        hevm.prank(msg.sender);
+        token.safeBatchTransferFrom(msg.sender, address(unsafeReceiver), ids,amounts,"");
+        assertWithMsg(false, "safeBatchTransferFrom does not revert if receiver does not implement ERC1155.onERC1155Received");
+    }
+
+    function _customMint(address to,uint id,uint amount) internal virtual;
+    
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal virtual;
+}

--- a/contracts/ERC1155/external/properties/ERC1155ExternalBurnableProperties.sol
+++ b/contracts/ERC1155/external/properties/ERC1155ExternalBurnableProperties.sol
@@ -1,0 +1,156 @@
+pragma solidity ^0.8.13;
+
+import "../util/ERC1155ExternalTestBase.sol";
+// import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
+import "../../../util/Hevm.sol";
+
+abstract contract CryticERC1155ExternalBurnableProperties is CryticERC1155ExternalTestBase{//,ERC1155Burnable {
+    using Address for address;
+    mapping(uint256 => uint256) private idToAmount;
+    ////////////////////////////////////////
+    // Properties
+
+    // The burn function should destroy tokens and balance
+    function test_ERC1155_external_burnDestroysTokens(uint256 id) public virtual {
+        require(isMintableOrBurnable);
+        uint256 selfBalance = token.balanceOf(msg.sender,id);
+        require(selfBalance > 0);
+        
+        hevm.prank(msg.sender);
+        token.burn(msg.sender,id,selfBalance);
+
+        assertWithMsg(token.balanceOf(msg.sender,id) == 0, "failed to update balance after burning");
+    }
+
+    function test_ERC1155_external_burnDestroysTokensFromApprovedAddress(address target,uint256 id) public virtual {
+        require(isMintableOrBurnable);
+        uint256 selfBalance = token.balanceOf(msg.sender,id);
+        require(selfBalance > 0);
+        require(target != msg.sender);
+        
+        // set approval
+        hevm.prank(msg.sender);
+        token.setApprovalForAll(target,true);
+
+        hevm.prank(target);
+        token.burn(msg.sender,id,selfBalance);
+
+        assertWithMsg(token.balanceOf(msg.sender,id) == 0, "failed to update balance after burning");
+    }
+    
+    // A burned token should not be transferrable
+    function test_ERC1155_external_burnRevertOnTransferFromPreviousOwner(address target,uint256 id) public virtual{
+        require(isMintableOrBurnable);
+        uint256 selfBalance = token.balanceOf(msg.sender,id);
+        require(selfBalance > 0);
+        
+        hevm.prank(msg.sender);
+        token.burn(msg.sender,id,selfBalance);
+
+        token.safeTransferFrom(msg.sender,target, id,1,"");
+        assertWithMsg(false, "Transferring a burned token didn't revert");
+    }
+
+    // burned token(s) should not be transferrable when burned with burnBatch
+    function test_ERC1155_external_burnBatchRevertOnTransferFromPreviousOwner(address target,uint256[] memory ids, uint256[] memory amounts) public virtual{
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            idToAmount[ids[i]]+=amounts[i];
+            require(token.balanceOf(msg.sender,ids[i])==0);
+        }
+        
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // balance for ids should be similar to amounts
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+        
+        // batch burn tokens
+        hevm.prank(msg.sender);
+        token.burnBatch(msg.sender,ids,amounts);
+
+        hevm.prank(msg.sender);
+        token.safeBatchTransferFrom(msg.sender,target,ids,amounts,"");
+
+        assertWithMsg(false, "Transferring burned tokens didn't revert");
+    }
+
+    function test_ERC1155_external_burnBatchDestroysTokens(uint256[] memory ids, uint256[] memory amounts) public virtual{
+        require(isMintableOrBurnable);
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            idToAmount[ids[i]]+=amounts[i];
+            require(token.balanceOf(msg.sender,ids[i])==0);
+        }
+        
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // balance for ids should be similar to amounts
+         for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+
+        hevm.prank(msg.sender);
+        // batch burn tokens
+        token.burnBatch(msg.sender,ids,amounts);
+
+        // Balance should have decreased
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(token.balanceOf(msg.sender,ids[i])==0, "Failed to mint expected balance amount to ids");
+        }
+    }
+
+    function test_ERC1155_external_burnBatchDestroysTokensFromApprovedAddress(address target, uint256[] memory ids, uint256[] memory amounts) public virtual{
+        require(isMintableOrBurnable);
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        require(target != msg.sender);
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            idToAmount[ids[i]]+=amounts[i];
+            require(token.balanceOf(msg.sender,ids[i])==0);
+        }
+        
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // balance for ids should be similar to amounts
+         for (uint256 i = 0; i < ids.length; i++) {
+            require(token.balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+
+        // set approval
+        hevm.prank(msg.sender);
+        token.setApprovalForAll(target,true);
+
+        hevm.prank(target);
+        // batch burn tokens
+        token.burnBatch(msg.sender,ids,amounts);
+
+        // Balance should have decreased
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(token.balanceOf(msg.sender,ids[i])==0, "Failed to mint expected balance amount to ids");
+        }
+    }
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal virtual;
+}

--- a/contracts/ERC1155/external/properties/ERC1155ExternalMintableProperties.sol
+++ b/contracts/ERC1155/external/properties/ERC1155ExternalMintableProperties.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.8.13;
+
+import "../util/ERC1155ExternalTestBase.sol";
+
+abstract contract CryticERC1155ExternalMintableProperties is CryticERC1155ExternalTestBase {
+    mapping(uint256 => uint256) private idToAmount;
+    ////////////////////////////////////////
+    // Properties
+    // mint increases the total supply
+    function test_ERC1155_external_mint(uint id,uint amount) public virtual {
+        require(isMintableOrBurnable);
+        // Check the target has 0 balance
+        uint256 selfBalance = token.balanceOf(msg.sender,id);
+        
+        _customMint(msg.sender,id,amount);
+
+        assertWithMsg(token.balanceOf(msg.sender,id)==selfBalance+amount, "Token balance of receiver not updated");
+    }
+
+    //_mintBatch Should mint tokens in batch
+    function test_ERC1155_external_mintBatchTokens(address target, uint256[] memory ids, uint256[] memory amounts) public virtual{
+        require(isMintableOrBurnable);
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        // balance for ids should be zero
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            require(token.balanceOf(target,ids[i])==0);
+            idToAmount[ids[i]]+=amounts[i];
+        }
+
+        // batch mint tokens
+        _customMintBatch(target,ids,amounts);
+
+        // Balance should have increased
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(token.balanceOf(target,ids[i])==idToAmount[ids[i]], "Failed to mint expected balance amount to ids");   
+        }
+
+        // deleting element in above loop will cause problem when there would be duplicate element in ids.
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+    }
+
+    // Wrappers
+    function _customMint(address to,uint id,uint amount) internal virtual;
+    
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal virtual;
+}

--- a/contracts/ERC1155/external/test/ERC1155Compliant.sol
+++ b/contracts/ERC1155/external/test/ERC1155Compliant.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
+
+contract ERC1155Compliant is ERC1155, ERC1155Burnable {
+    bool public isMintableOrBurnable;
+    constructor() ERC1155("tokenUrl//") {}
+
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) public {
+        _mintBatch(target,ids,amounts,"");
+    }
+
+    function mint(address to,uint256 id,uint256 amount) public {
+        _mint(to,id,amount,"");
+    }
+
+    // Overrides
+
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override(ERC1155)
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC1155)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/ERC1155/external/test/echidna.config.yaml
+++ b/contracts/ERC1155/external/test/echidna.config.yaml
@@ -1,0 +1,10 @@
+corpusDir: "corpus-ext"
+coverage: true 
+allContracts: true
+testMode: assertion
+testLimit: 100000
+deployer: "0x10000"
+sender: ["0x10000", "0x20000", "0x30000"]
+cryticArgs:
+ - --solc-remaps
+ - ds-test/=lib/forge-std/lib/ds-test/src/ forge-std/=lib/forge-std/src/ solmate/=lib/solmate/ @openzeppelin/=lib/openzeppelin-contracts/

--- a/contracts/ERC1155/external/test/standard/ERC1155BasicTests.sol
+++ b/contracts/ERC1155/external/test/standard/ERC1155BasicTests.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.8.0;
+
+import {CryticERC1155ExternalBasicProperties} from "../../properties/ERC1155ExternalBasicProperties.sol";
+import {ERC1155IncorrectBasic} from "../../util/ERC1155IncorrectBasic.sol";
+import {IERC1155Internal} from "../../../util/IERC1155Internal.sol";
+import {MockReceiver} from "../../util/MockReceiver.sol";
+
+contract ERC1155BasicExternalHarness is CryticERC1155ExternalBasicProperties {
+    constructor() {
+        token = IERC1155Internal(address(new ERC1155IncorrectBasic()));
+        safeReceiver = new MockReceiver(true);
+        unsafeReceiver = new MockReceiver(false);
+    }
+
+    function _customMint(address to,uint id,uint amount) internal override {
+        token.mint(to,id,amount);
+    }
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal override{
+        token.mintBatch(target,ids,amounts);
+    }
+}

--- a/contracts/ERC1155/external/test/standard/ERC1155BurnableTests.sol
+++ b/contracts/ERC1155/external/test/standard/ERC1155BurnableTests.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.8.0;
+
+import {CryticERC1155ExternalBurnableProperties} from "../../properties/ERC1155ExternalBurnableProperties.sol";
+import {ERC1155IncorrectBurnable} from "../../util/ERC1155IncorrectBurnable.sol";
+import {IERC1155Internal} from "../../../util/IERC1155Internal.sol";
+import {MockReceiver} from "../../util/MockReceiver.sol";
+
+contract ERC1155BurnableExternalHarness is CryticERC1155ExternalBurnableProperties {
+    constructor() {
+        token = IERC1155Internal(address(new ERC1155IncorrectBurnable()));
+        safeReceiver = new MockReceiver(true);
+        unsafeReceiver = new MockReceiver(false);
+        isMintableOrBurnable=true;
+    }
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal override{
+        token.mintBatch(target,ids,amounts);
+    }
+
+
+}

--- a/contracts/ERC1155/external/test/standard/ERC1155CompliantTests.sol
+++ b/contracts/ERC1155/external/test/standard/ERC1155CompliantTests.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.8.0;
+
+import {CryticERC1155ExternalPropertyTests} from "../../ERC1155ExternalPropertyTests.sol";
+import {ERC1155Compliant} from "../ERC1155Compliant.sol";
+import {IERC1155Internal} from "../../../util/IERC1155Internal.sol";
+import {MockReceiver} from "../../util/MockReceiver.sol";
+
+contract ERC1155CompliantExternalHarness is CryticERC1155ExternalPropertyTests {
+    constructor() {
+        token = IERC1155Internal(address(new ERC1155Compliant()));
+        safeReceiver = new MockReceiver(true);
+        unsafeReceiver = new MockReceiver(false);
+        isMintableOrBurnable=true;
+    }
+
+    function _customMint(address to,uint id,uint amount) internal override {
+        token.mint(to,id,amount);
+    }
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal override{
+        token.mintBatch(target,ids,amounts);
+    }
+}

--- a/contracts/ERC1155/external/test/standard/ERC1155MintableTests.sol
+++ b/contracts/ERC1155/external/test/standard/ERC1155MintableTests.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.8.0;
+
+import {CryticERC1155ExternalMintableProperties} from "../../properties/ERC1155ExternalMintableProperties.sol";
+import {ERC1155IncorrectMintable} from "../../util/ERC1155IncorrectMintable.sol";
+import {IERC1155Internal} from "../../../util/IERC1155Internal.sol";
+import {MockReceiver} from "../../util/MockReceiver.sol";
+
+contract ERC1155MintableExternalHarness is CryticERC1155ExternalMintableProperties {
+    constructor() {
+        token = IERC1155Internal(address(new ERC1155IncorrectMintable()));
+        safeReceiver = new MockReceiver(true);
+        unsafeReceiver = new MockReceiver(false);
+        isMintableOrBurnable=true;
+    }
+
+    function _customMint(address to,uint id,uint amount) internal override {
+        token.mint(to,id,amount);
+    }
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal override{
+        token.mintBatch(target,ids,amounts);
+    }
+}

--- a/contracts/ERC1155/external/util/ERC1155ExternalTestBase.sol
+++ b/contracts/ERC1155/external/util/ERC1155ExternalTestBase.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.8.0;
+
+import "../../../util/PropertiesHelper.sol";
+import "../../util/IERC1155Internal.sol";
+import "../../../util/PropertiesConstants.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import {MockReceiver} from "./MockReceiver.sol";
+
+
+abstract contract CryticERC1155ExternalTestBase is PropertiesAsserts, PropertiesConstants {
+ 
+    // Is the contract allowed to change its total supply?
+    bool isMintableOrBurnable;
+    IERC1155Internal public token;
+    MockReceiver public safeReceiver;
+    MockReceiver public unsafeReceiver;
+
+    constructor() {
+    }
+
+}

--- a/contracts/ERC1155/external/util/ERC1155IncorrectBasic.sol
+++ b/contracts/ERC1155/external/util/ERC1155IncorrectBasic.sol
@@ -1,0 +1,55 @@
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+contract ERC1155IncorrectBasic is ERC1155{
+    
+    uint256 public counter;
+    constructor() ERC1155("tokenUrl//") {}
+
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) public {
+        //_mintBatch(target,ids,amounts,"");
+    }
+
+    function mint(address to,uint256 id,uint256 amount) public {
+        //_mint(to,id,amount,"");
+    }
+
+    function balanceOf(address account, uint256 id) public view virtual override returns (uint256) {
+        // require(account != address(0), "ERC1155: address zero is not a valid owner");
+        return account == address(0) ? 0 : super.balanceOf(account,id);
+    }
+
+    function safeTransferFrom( address from, address to, uint256 id, uint256 amount, bytes memory data ) public virtual override {
+        //solhint-disable-next-line max-line-length
+        // require( from == _msgSender() || isApprovedForAll(from, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (from == to) {
+            _mint(to,id,amount,"");
+        }
+    }
+
+    function safeBatchTransferFrom( address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data ) public virtual override {
+        // require( from == _msgSender() || isApprovedForAll(from, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (from == to) {
+            _mintBatch(to,ids,amounts,"");
+        }
+    }
+
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override(ERC1155)
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC1155)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/ERC1155/external/util/ERC1155IncorrectBurnable.sol
+++ b/contracts/ERC1155/external/util/ERC1155IncorrectBurnable.sol
@@ -1,0 +1,56 @@
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
+
+contract ERC1155IncorrectBurnable is ERC1155, ERC1155Burnable {
+    
+    uint256 public counter;
+    constructor() ERC1155("tokenUrl//") {}
+
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) public {
+        _mintBatch(target,ids,amounts,"");
+    }
+
+    function mint(address to,uint256 id,uint256 amount) public {
+        _mint(to,id,amount,"");
+    }
+
+    function burn(address account, uint256 id, uint256 amount) public virtual override{
+        // require( account == _msgSender() || isApprovedForAll(account, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (id % 2 == 0) {
+            _mint(account,id,amount,"");
+        } else {
+            _burn(account, id, amount);
+        }
+    }
+
+    function burnBatch(address account, uint256[] memory ids, uint256[] memory amounts) public virtual override{
+        //require( account == _msgSender() || isApprovedForAll(account, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        for( uint256 i;i<ids.length;i++){
+            if (ids[i] % 2 == 0) {
+                 _mint(account,ids[i],amounts[i],"");
+            } else {
+                _burn(account,ids[i],amounts[i]);
+            }
+        }
+    }
+
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override(ERC1155)
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC1155)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/ERC1155/external/util/ERC1155IncorrectMintable.sol
+++ b/contracts/ERC1155/external/util/ERC1155IncorrectMintable.sol
@@ -1,0 +1,55 @@
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+contract ERC1155IncorrectMintable is ERC1155{
+    
+    uint256 public counter;
+    constructor() ERC1155("tokenUrl//") {}
+
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) public {
+        //_mintBatch(target,ids,amounts,"");
+    }
+
+    function mint(address to,uint256 id,uint256 amount) public {
+        //_mint(to,id,amount,"");
+    }
+
+    // function burn(address account, uint256 id, uint256 amount) public virtual override{
+    //     // require( account == _msgSender() || isApprovedForAll(account, _msgSender()), "ERC1155: caller is not token owner or approved" );
+    //     if (id % 2 == 0) {
+    //         _mint(account,id,amount,"");
+    //     } else {
+    //         _burn(account, id, amount);
+    //     }
+    // }
+
+    // function burnBatch(address account, uint256[] memory ids, uint256[] memory amounts) public virtual override{
+    //     //require( account == _msgSender() || isApprovedForAll(account, _msgSender()), "ERC1155: caller is not token owner or approved" );
+    //     for( uint256 i;i<ids.length;i++){
+    //         if (ids[i] % 2 == 0) {
+    //              _mint(account,ids[i],amounts[i],"");
+    //         } else {
+    //             _burn(account,ids[i],amounts[i]);
+    //         }
+    //     }
+    // }
+
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override(ERC1155)
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC1155)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/ERC1155/external/util/MockReceiver.sol
+++ b/contracts/ERC1155/external/util/MockReceiver.sol
@@ -1,0 +1,27 @@
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+
+contract MockReceiver is ERC1155Holder {
+    bool shouldReceive;
+
+    constructor(bool _shouldReceive) {
+        shouldReceive = _shouldReceive;
+    }
+
+    function onERC1155Received( address, address, uint256, uint256, bytes memory ) public virtual override returns (bytes4) {
+        if (shouldReceive) {
+            return this.onERC1155Received.selector;
+        }
+
+        return bytes4(0);
+    }
+
+    function onERC1155BatchReceived( address, address, uint256[] memory, uint256[] memory, bytes memory ) public virtual override returns (bytes4) {
+        if (shouldReceive) {
+            return this.onERC1155BatchReceived.selector;
+        }
+
+        return bytes4(0);
+    }
+}

--- a/contracts/ERC1155/internal/ERC1155InternalPropertyTests.sol
+++ b/contracts/ERC1155/internal/ERC1155InternalPropertyTests.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.8.13;
+
+import {CryticERC1155TestBase} from "./util/ERC1155TestBase.sol";
+import {CryticERC1155BasicProperties} from "./properties/ERC1155BasicProperties.sol";
+import {CryticERC1155BurnableProperties} from "./properties/ERC1155BurnableProperties.sol";
+import {CryticERC1155MintableProperties} from "./properties/ERC1155MintableProperties.sol";
+
+/// @notice Aggregator contract for various ERC1155 property tests. Inherit from this & echidna will test all properties at the same time.
+abstract contract CryticERC1155InternalPropertyTests is CryticERC1155BasicProperties, CryticERC1155MintableProperties, CryticERC1155BurnableProperties  {
+
+    // The following functions are overrides required by Solidity.
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override(CryticERC1155TestBase,CryticERC1155BurnableProperties)
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(CryticERC1155BurnableProperties, CryticERC1155TestBase)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _customMint(address to,uint id,uint amount) internal virtual override(CryticERC1155BasicProperties,CryticERC1155MintableProperties);
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal virtual override(CryticERC1155BasicProperties,CryticERC1155BurnableProperties,CryticERC1155MintableProperties);
+} 

--- a/contracts/ERC1155/internal/properties/ERC1155BasicProperties.sol
+++ b/contracts/ERC1155/internal/properties/ERC1155BasicProperties.sol
@@ -1,0 +1,203 @@
+pragma solidity ^0.8.13;
+
+import "../util/ERC1155TestBase.sol";
+
+abstract contract CryticERC1155BasicProperties is CryticERC1155TestBase{
+    using Address for address;
+    mapping(uint256 => uint256) private idToAmount;
+    
+    ////////////////////////////////////////
+    // Properties
+
+    // Querying the balance of address(0) should throw
+    function test_ERC1155_balanceOfZeroAddressMustRevert() public virtual {
+        balanceOf(address(0),1);
+        assertWithMsg(false, "address(0) balance query should have reverted");
+    }
+
+    // balanceOfBatch works as expected
+    function test_ERC1155_balanceOfBatchWorksAsExpected(address[] memory targets,uint256[] memory ids,uint256[] memory amounts) public virtual{
+        // target,ids and amounts should have same length.
+        require(targets.length==ids.length);
+        
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(targets[i],ids[i])==0);
+        }
+        
+        // mint tokens to target
+        for (uint256 i = 0; i < ids.length; i++) {
+            _customMint(targets[i],ids[i],amounts[i]);
+        }
+        
+        // check balanceOfBatch gives same balances
+        uint256[] memory balances;
+        balances = balanceOfBatch(targets,ids);
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(balances[i]==balanceOf(targets[i],ids[i]), "Failed to return expected balance amount to for id");
+        }
+    }
+
+    // safeTransferFrom a token that the caller is not approved for should revert
+     function test_ERC1155_transferFromNotApproved(address target,uint256 id,uint256 amount) public virtual {
+        uint256 selfBalance = balanceOf(target,id);
+        require(selfBalance >= amount);        
+        require(target != address(this));
+        require(target != msg.sender);
+        _setApprovalForAll(target, msg.sender, false);
+
+        safeTransferFrom(target, msg.sender, id,amount,"");
+        assertWithMsg(false, "using safeTransferFrom without being approved should have reverted");
+    }
+
+    // safeTransferFrom correctly updates balance
+    function test_ERC1155_transferFromUpdatesBalance(address target, uint256 id,uint256 amount) public virtual {
+        uint256 selfBalanceBefore = balanceOf(msg.sender,id);
+        uint256 targetBalanceBefore = balanceOf(target,id);
+        require(selfBalanceBefore >= amount);
+        require(target != address(this));
+        require(target != msg.sender);
+        require(!Address.isContract(target));
+        hevm.prank(msg.sender);
+        try IERC1155(address(this)).safeTransferFrom(msg.sender,target, id,amount,"") {
+        uint256 targetBalanceAfter = balanceOf(target,id);
+        uint256 selfBalanceAfter = balanceOf(msg.sender,id);
+            assertWithMsg(targetBalanceBefore+amount ==targetBalanceAfter, "Token balance of receiver not updated");
+            assertWithMsg(selfBalanceBefore-amount ==selfBalanceAfter, "Token balance target not updated");
+        } catch {
+            assertWithMsg(false, "safeTransferFrom unexpectedly reverted");
+        }
+    }
+    
+    // transfer from zero address should revert/throw
+    function test_ERC1155_transferFromZeroAddress(uint256 id,uint256 amount) public virtual {
+        safeTransferFrom(address(0), msg.sender, id,amount,"");
+
+        assertWithMsg(false, "Transfer from zero address did not revert");
+    }
+
+    // transfer to zero address should revert
+    function test_ERC1155_transferFromToZeroAddress(uint256 id,uint256 amount) public virtual {
+        uint256 selfBalance = balanceOf(msg.sender,id);
+        require(selfBalance >= amount); 
+
+        safeTransferFrom(msg.sender, address(0), id,amount,"");
+
+        assertWithMsg(false, "Transfer to zero address did not revert");
+    }
+
+    // Transfers to self should not break accounting
+     function test_ERC1155_transferFromSelf(uint256 id,uint256 amount) public virtual {
+        uint256 selfBalance = balanceOf(msg.sender,id);
+        require(selfBalance >= amount); 
+        
+        hevm.prank(msg.sender);
+
+        // transfer amount token of id to self address from self address.
+        try IERC1155(address(this)).safeTransferFrom(msg.sender, msg.sender, id,amount,"") {
+            assertWithMsg(selfBalance==balanceOf(msg.sender,id), "Self transfer breaks accounting");
+        } catch {
+            assertWithMsg(false, "safeTransferFrom unexpectedly reverted");
+        }
+    }
+
+    // Batch transfer to self should not break accounting
+    function test_ERC1155_safeBatchTransferFromSelf(uint256[] memory ids,uint256[] memory amounts) public virtual {
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            require(balanceOf(msg.sender,ids[i])==0);
+            idToAmount[ids[i]]+=amounts[i];
+        }
+
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // balance for ids should be similar to amounts
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+        
+        // batch trasnfer tokens
+        safeBatchTransferFrom(msg.sender,msg.sender,ids,amounts,"");
+
+        // Balance should be same.
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(balanceOf(msg.sender,ids[i])==idToAmount[ids[i]], "Failed to mint expected balance amount to ids");
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+    }
+
+    // safeBatchTransferFrom correctly updates balance
+    function test_ERC1155_safeBatchTransferFrom(address target,uint256[] memory ids,uint256[] memory amounts) public virtual {
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        // sender's balance for ids should be equal to 0.
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(msg.sender,ids[i])==0);
+            idToAmount[ids[i]]+=amounts[i];
+        }
+
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // sender's balance for ids should be equal to amounts.
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+
+        // receiver's balance for ids should be 0
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(target,ids[i])==0);
+        }
+
+        // batch transfer tokens
+        safeBatchTransferFrom(msg.sender,target,ids,amounts,"");
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(balanceOf(msg.sender,ids[i])==0, "Failed to update sender's balance");
+        }
+
+        // Balance should have increased
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(balanceOf(target,ids[i])==idToAmount[ids[i]], "Failed to mint expected balance amount to target");
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+    }
+
+    // safeTransferFrom reverts if receiver does not implement the callback
+    function test_ERC1155_safeTransferFromRevertsOnNoncontractReceiver(uint256 id,uint256 amount) public virtual {
+        uint256 selfBalance = balanceOf(msg.sender,id);
+        require(selfBalance >= amount); 
+        
+        safeTransferFrom(msg.sender, address(unsafeReceiver), id,amount,"");
+        assertWithMsg(false, "safeTransferFrom does not revert if receiver does not implement ERC1155.onERC1155Received");
+    }
+
+    // safeBatchTransferFrom reverts if receiver does not implement the callback
+    function test_ERC1155_safeBatchTransferFromRevertsOnNoncontractReceiver(uint256[] memory ids,uint256[] memory amounts) public virtual {
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(msg.sender,ids[i])>=amounts[i]);
+        }
+        
+        safeBatchTransferFrom(msg.sender, address(unsafeReceiver), ids,amounts,"");
+        assertWithMsg(false, "safeBatchTransferFrom does not revert if receiver does not implement ERC1155.onERC1155Received");
+    }
+
+    function _customMint(address to,uint id,uint amount) internal virtual;
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal virtual;
+}

--- a/contracts/ERC1155/internal/properties/ERC1155BurnableProperties.sol
+++ b/contracts/ERC1155/internal/properties/ERC1155BurnableProperties.sol
@@ -1,0 +1,171 @@
+pragma solidity ^0.8.13;
+
+import "../util/ERC1155TestBase.sol";
+import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
+
+abstract contract CryticERC1155BurnableProperties is CryticERC1155TestBase,ERC1155Burnable {
+    using Address for address;
+    mapping(uint256 => uint256) private idToAmount;
+    ////////////////////////////////////////
+    // Properties
+
+    // The burn function should destroy tokens and balance
+    function test_ERC1155_burnDestroysTokens(uint256 id) public virtual {
+        require(isMintableOrBurnable);
+        uint256 selfBalance = balanceOf(msg.sender,id);
+        require(selfBalance > 0);
+
+        burn(msg.sender,id,selfBalance);
+
+        assertWithMsg(balanceOf(msg.sender,id) == 0, "failed to update balance after burning");
+    }
+
+    // The approved address should be able to destroy tokens
+    function test_ERC1155_burnDestroysTokensFromApprovedAddress(address target, uint256 id) public virtual {
+        require(isMintableOrBurnable);
+        uint256 selfBalance = balanceOf(msg.sender,id);
+        require(selfBalance > 0);
+        require(target != msg.sender);
+
+        // set approval
+        setApprovalForAll(target,true);
+
+        hevm.prank(target);
+        burn(msg.sender,id,selfBalance);
+
+        assertWithMsg(balanceOf(msg.sender,id) == 0, "failed to update balance after burning");
+    }
+    
+    // A burned token should not be transferrable
+    function test_ERC1155_burnRevertOnTransferFromPreviousOwner(address target,uint256 id) public virtual{
+        require(isMintableOrBurnable);
+        uint256 selfBalance = balanceOf(msg.sender,id);
+        require(selfBalance > 0);
+
+        burn(msg.sender,id,selfBalance);
+
+        safeTransferFrom(msg.sender,target, id,1,"");
+        assertWithMsg(false, "Transferring a burned token didn't revert");
+    }
+
+    // burned token(s) should not be transferrable when burned with burnBatch
+    function test_ERC1155_burnBatchRevertOnTransferFromPreviousOwner(address target,uint256[] memory ids, uint256[] memory amounts) public virtual{
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            idToAmount[ids[i]]+=amounts[i];
+            require(balanceOf(msg.sender,ids[i])==0);
+        }
+        
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // balance for ids should be similar to amounts
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+
+        // batch burn tokens
+        burnBatch(msg.sender,ids,amounts);
+
+        safeBatchTransferFrom(msg.sender,target,ids,amounts,"");
+
+        assertWithMsg(false, "Transferring burned tokens didn't revert");
+    }
+
+    
+
+    function test_ERC1155_burnBatchDestroysTokens(uint256[] memory ids, uint256[] memory amounts) public virtual{
+        require(isMintableOrBurnable);
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            idToAmount[ids[i]]+=amounts[i];
+            require(balanceOf(msg.sender,ids[i])==0);
+        }
+        
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // balance for ids should be similar to amounts
+         for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+
+        // batch burn tokens
+        burnBatch(msg.sender,ids,amounts);
+
+        // Balance should have decreased
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(balanceOf(msg.sender,ids[i])==0, "Failed to mint expected balance amount to ids");
+        }
+    }
+
+    function test_ERC1155_burnBatchDestroysTokensFromApprovedAddress(address target, uint256[] memory ids, uint256[] memory amounts) public virtual{
+        require(isMintableOrBurnable);
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        require(target != msg.sender);
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            idToAmount[ids[i]]+=amounts[i];
+            require(balanceOf(msg.sender,ids[i])==0);
+        }
+        
+        // batch mint tokens
+        _customMintBatch(msg.sender,ids,amounts);
+
+        // balance for ids should be similar to amounts
+         for (uint256 i = 0; i < ids.length; i++) {
+            require(balanceOf(msg.sender,ids[i])==idToAmount[ids[i]]);
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+
+        // set approval
+        setApprovalForAll(target,true);
+
+        hevm.prank(target);
+        // batch burn tokens
+        burnBatch(msg.sender,ids,amounts);
+
+        // Balance should have decreased
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(balanceOf(msg.sender,ids[i])==0, "Failed to mint expected balance amount to ids");
+        }
+    }
+
+    // The following functions are overrides required by Solidity.
+
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override(ERC1155, CryticERC1155TestBase)
+    {
+        super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC1155, CryticERC1155TestBase)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal virtual;
+}

--- a/contracts/ERC1155/internal/properties/ERC1155MintableProperties.sol
+++ b/contracts/ERC1155/internal/properties/ERC1155MintableProperties.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.8.13;
+
+import "../util/ERC1155TestBase.sol";
+
+abstract contract CryticERC1155MintableProperties is CryticERC1155TestBase{
+    mapping(uint256 => uint256) private idToAmount;
+    ////////////////////////////////////////
+    // Properties
+    // Should mint tokens and should increase balance
+    function test_ERC1155_mint(uint id,uint amount) public virtual {
+        require(isMintableOrBurnable);
+        // Check the target has 0 balance
+        uint256 selfBalance = balanceOf(msg.sender,id);
+        
+        _customMint(msg.sender,id,amount);
+
+        assertWithMsg(balanceOf(msg.sender,id)==selfBalance+amount, "Token balance of receiver not updated");
+    }
+
+    // Should mint tokens in batch and should increase balance
+    function test_ERC1155_mintBatchTokens(address target, uint256[] memory ids, uint256[] memory amounts) public virtual{
+        require(isMintableOrBurnable);
+        // ids and amounts should have same length.
+        require(ids.length==amounts.length);
+        // balance for ids should be zero
+        for (uint256 i = 0; i < ids.length; i++) {
+            require(amounts[i]>0);
+            require(balanceOf(target,ids[i])==0);
+            idToAmount[ids[i]]+=amounts[i];
+        }
+
+        // batch mint tokens
+        _customMintBatch(target,ids,amounts);
+
+        // Balance should have increased
+        for (uint256 i = 0; i < ids.length; i++) {
+            assertWithMsg(balanceOf(target,ids[i])==idToAmount[ids[i]], "Failed to mint expected balance amount to ids");
+        }
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            delete idToAmount[ids[i]];
+        }
+    }
+
+    // Wrappers
+    function _customMint(address to,uint id,uint amount) internal virtual;
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal virtual;
+}

--- a/contracts/ERC1155/internal/test/configInternal.yaml
+++ b/contracts/ERC1155/internal/test/configInternal.yaml
@@ -1,0 +1,10 @@
+coverage: true 
+corpusDir: "corpus"
+testMode: assertion
+testLimit: 100000
+deployer: "0x10000"
+sender: ["0x10000", "0x20000", "0x30000"]
+
+cryticArgs:
+ - --solc-remaps
+ - ds-test/=lib/forge-std/lib/ds-test/src/ forge-std/=lib/forge-std/src/ solmate/=lib/solmate/ @openzeppelin/=lib/openzeppelin-contracts/

--- a/contracts/ERC1155/internal/test/standard/ERC1155BasicTests.sol
+++ b/contracts/ERC1155/internal/test/standard/ERC1155BasicTests.sol
@@ -1,0 +1,74 @@
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {CryticERC1155BasicProperties} from "../../properties/ERC1155BasicProperties.sol";
+import {MockReceiver} from "../../util/MockReceiver.sol";
+
+contract ERC1155BasicTestsInternal is CryticERC1155BasicProperties {
+    using Address for address;
+
+    constructor() ERC1155("url//") {
+        isMintableOrBurnable = false;
+        safeReceiver = new MockReceiver(true);
+        unsafeReceiver = new MockReceiver(false);
+    }
+
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) public {
+        _mintBatch(target,ids,amounts,"");
+    }
+
+    function mint(address to,uint256 id,uint256 amount) public {
+        _mint(to,id,amount,"");
+    }
+    function _customMint(address to,uint id,uint amount) internal override{
+        mint(to,id,amount);
+    }
+
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal override{
+        mintBatch(target,ids,amounts);
+    }
+
+    function balanceOf(address account, uint256 id) public view virtual override returns (uint256) {
+        // require(account != address(0), "ERC1155: address zero is not a valid owner");
+        return account == address(0) ? 0 : super.balanceOf(account,id);
+    }
+
+    function safeTransferFrom( address from, address to, uint256 id, uint256 amount, bytes memory data ) public virtual override {
+        //solhint-disable-next-line max-line-length
+        // require( from == _msgSender() || isApprovedForAll(from, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (from == to) {
+            _mint(to,id,amount,"");
+        }
+    }
+
+    function safeBatchTransferFrom( address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data ) public virtual override {
+        // require( from == _msgSender() || isApprovedForAll(from, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (from == to) {
+            _mintBatch(to,ids,amounts,"");
+        }
+    }
+    
+    // The following functions are overrides required by Solidity.
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+}
+
+contract ERC1155InternalBasic is ERC1155BasicTestsInternal {
+    constructor() {}
+}

--- a/contracts/ERC1155/internal/test/standard/ERC1155BurnableTests.sol
+++ b/contracts/ERC1155/internal/test/standard/ERC1155BurnableTests.sol
@@ -1,0 +1,94 @@
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {CryticERC1155BurnableProperties} from "../../properties/ERC1155BurnableProperties.sol";
+import {MockReceiver} from "../../util/MockReceiver.sol";
+
+contract ERC1155BurnableTestsInternal is CryticERC1155BurnableProperties {
+    using Address for address;
+    
+    uint256 public counter;
+
+    constructor() ERC1155("url//") {
+        isMintableOrBurnable = true;
+        safeReceiver = new MockReceiver(true);
+        unsafeReceiver = new MockReceiver(false);
+    }
+
+    function burn(address account, uint256 id, uint256 amount) public virtual override{
+        // require( account == _msgSender() || isApprovedForAll(account, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (id % 2 == 0) {
+            _mint(account,id,amount,"");
+        } else {
+            _burn(account, id, amount);
+        }
+    }
+
+    function burnBatch(address account, uint256[] memory ids, uint256[] memory amounts) public virtual override{
+        //require( account == _msgSender() || isApprovedForAll(account, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        for( uint256 i;i<ids.length;i++){
+            if (ids[i] % 2 == 0) {
+                 _mint(account,ids[i],amounts[i],"");
+            } else {
+                _burn(account,ids[i],amounts[i]);
+            }
+        }
+    }
+
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) public {
+        _mintBatch(target,ids,amounts,"");
+    }
+
+    //  function _customMint(address to,uint id,uint amount) internal override {
+    //     _mint(to,id,amount,"");
+    // }
+    
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal override{
+        mintBatch(target,ids,amounts);
+    }
+
+    function balanceOf(address account, uint256 id) public view virtual override returns (uint256) {
+        // require(account != address(0), "ERC1155: address zero is not a valid owner");
+        return account == address(0) ? 0 : super.balanceOf(account,id);
+    }
+
+    function safeTransferFrom( address from, address to, uint256 id, uint256 amount, bytes memory data ) public virtual override {
+        //solhint-disable-next-line max-line-length
+        // require( from == _msgSender() || isApprovedForAll(from, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (from == to) {
+            _mint(to,id,amount,"");
+        }
+    }
+
+    function safeBatchTransferFrom( address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data ) public virtual override {
+        // require( from == _msgSender() || isApprovedForAll(from, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (from == to) {
+            _mintBatch(to,ids,amounts,"");
+        }
+    }
+    
+    // The following functions are overrides required by Solidity.
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+
+}
+
+contract ERC1155InternalBurnable is ERC1155BurnableTestsInternal {
+    constructor() {}
+}

--- a/contracts/ERC1155/internal/test/standard/ERC1155Compliant.sol
+++ b/contracts/ERC1155/internal/test/standard/ERC1155Compliant.sol
@@ -1,0 +1,55 @@
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {CryticERC1155InternalPropertyTests} from "../../ERC1155InternalPropertyTests.sol";
+import {MockReceiver} from "../../util/MockReceiver.sol";
+
+contract ERC1155Compliant is CryticERC1155InternalPropertyTests {
+    using Address for address;
+
+    constructor() ERC1155("url//") {
+        isMintableOrBurnable = true;
+        safeReceiver = new MockReceiver(true);
+        unsafeReceiver = new MockReceiver(false);
+    }
+
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) public {
+        _mintBatch(target,ids,amounts,"");
+    }
+
+    function mint(address to,uint256 id,uint256 amount) public {
+        _mint(to,id,amount,"");
+    }
+
+    function _customMint(address to,uint id,uint amount) internal override {
+        mint(to,id,amount);
+    }
+    
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal override{
+        mintBatch(target,ids,amounts);
+    }
+    
+    // The following functions are overrides required by Solidity.
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+}
+
+contract ERC1155InternalCompliant is ERC1155Compliant {
+    constructor() {}
+}

--- a/contracts/ERC1155/internal/test/standard/ERC1155MintableTests.sol
+++ b/contracts/ERC1155/internal/test/standard/ERC1155MintableTests.sol
@@ -1,0 +1,78 @@
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {CryticERC1155MintableProperties} from "../../properties/ERC1155MintableProperties.sol";
+import {MockReceiver} from "../../util/MockReceiver.sol";
+
+contract ERC1155MintableTestsInternal is CryticERC1155MintableProperties {
+    using Address for address;
+    
+    uint256 public counter;
+
+    constructor() ERC1155("url//") {
+        isMintableOrBurnable = true;
+        safeReceiver = new MockReceiver(true);
+        unsafeReceiver = new MockReceiver(false);
+    }
+
+    function mint(address to, uint256 id, uint256 amount) public {
+        //require(totalSupply() + amount <= maxSupply);
+        // _mint(to,id,amount,"");
+    }
+
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) public {
+        // _mintBatch(target,ids,amounts,"");
+    }
+
+    function _customMint(address to,uint id,uint amount) internal override {
+        mint(to,id,amount);
+    }
+    
+    function _customMintBatch(address target, uint256[] memory ids, uint256[] memory amounts) internal override{
+        mintBatch(target,ids,amounts);
+    }
+
+    function balanceOf(address account, uint256 id) public view virtual override returns (uint256) {
+        // require(account != address(0), "ERC1155: address zero is not a valid owner");
+        return account == address(0) ? 0 : super.balanceOf(account,id);
+    }
+
+    function safeTransferFrom( address from, address to, uint256 id, uint256 amount, bytes memory data ) public virtual override {
+        //solhint-disable-next-line max-line-length
+        // require( from == _msgSender() || isApprovedForAll(from, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (from == to) {
+            _mint(to,id,amount,"");
+        }
+    }
+
+    function safeBatchTransferFrom( address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data ) public virtual override {
+        // require( from == _msgSender() || isApprovedForAll(from, _msgSender()), "ERC1155: caller is not token owner or approved" );
+        if (from == to) {
+            _mintBatch(to,ids,amounts,"");
+        }
+    }
+    
+    // The following functions are overrides required by Solidity.
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+   
+}
+
+contract ERC1155InternalMintable is ERC1155MintableTestsInternal {
+    constructor() {}
+}

--- a/contracts/ERC1155/internal/util/ERC1155TestBase.sol
+++ b/contracts/ERC1155/internal/util/ERC1155TestBase.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "../../../util/PropertiesConstants.sol";
+import "../../../util/PropertiesHelper.sol";
+import {MockReceiver} from "./MockReceiver.sol";
+import "../../../util/Hevm.sol";
+
+abstract contract CryticERC1155TestBase is ERC1155, PropertiesAsserts, PropertiesConstants {
+
+    // Is the contract allowed to change its total supply?
+    bool isMintableOrBurnable;
+    MockReceiver safeReceiver;
+    MockReceiver unsafeReceiver;
+
+    // The following functions are overrides required by Solidity.
+    function _beforeTokenTransfer( address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data )
+        internal
+        virtual
+        override(ERC1155)
+    {
+        super._beforeTokenTransfer(operator,from,to,ids,amounts,data );
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC1155)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/ERC1155/internal/util/MockReceiver.sol
+++ b/contracts/ERC1155/internal/util/MockReceiver.sol
@@ -1,0 +1,27 @@
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+
+contract MockReceiver is ERC1155Holder {
+    bool shouldReceive;
+
+    constructor(bool _shouldReceive) {
+        shouldReceive = _shouldReceive;
+    }
+
+    function onERC1155Received( address, address, uint256, uint256, bytes memory ) public virtual override returns (bytes4) {
+        if (shouldReceive) {
+            return this.onERC1155Received.selector;
+        }
+
+        return bytes4(0);
+    }
+
+    function onERC1155BatchReceived( address, address, uint256[] memory, uint256[] memory, bytes memory ) public virtual override returns (bytes4) {
+        if (shouldReceive) {
+            return this.onERC1155BatchReceived.selector;
+        }
+
+        return bytes4(0);
+    }
+}

--- a/contracts/ERC1155/util/IERC1155Internal.sol
+++ b/contracts/ERC1155/util/IERC1155Internal.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
+interface IERC1155Internal is IERC1155 {
+    function isMintableOrBurnable() external returns (bool);
+    function burn(address account,uint256 id,uint256 value) external;
+    function mint(address to,uint256 id,uint256 amount) external;
+    function _customMint(address to,uint id,uint amount) external;
+    function mintBatch(address target, uint256[] memory ids, uint256[] memory amounts) external;
+    function burnBatch(address account, uint256[] memory ids, uint256[] memory values) external;
+}


### PR DESCRIPTION
## It includes following ERC1155 internal and external properties:  

### Basic properties
- `balanceOf()` should revert on address zero
- `balanceOfBatch` Works as expected
- `safeTransferFrom()` should revert while transferring unapproved token
- `safeTransferFrom()` correctly update balances
- `safeTransferFrom()` should revert if `from` is the zero address
- `safeTransferFrom()` should revert if `to` is the zero address
- `safeTransferFrom()` to self should not break accounting
- `safeBatchTransferFrom()` to self should not break accounting
- `safeBatchTransferFrom()` correctly update balances
- `safeTransferFrom()` should revert if the receiver is a contract that does not implement onERC1155Received()
- `safeBatchTransferFrom()` should revert if the receiver is a contract that does not implement onERC1155Received()

### Burnable properties 
- `burn()` destroys token(s)
- `burn()` destroys token(s) from approved address
- `burnBatch()` destroys token(s)
- `burnBatch()` destroys token(s) from approved address
- cannot transfer a burned token
- burned token(s) should not be transferrable when burned with burnBatch

### Mintable properties
- Should mint tokens and should increase balance
- Should mint tokens in batch and should increase balance

---
This doesn't include `properites/test` for erc1155 properties but it includes `contracts/ERC1155/external/test/` and `contracts/ERC1155/internal/test/`