### PR TITLE
Adding UniswapV2 properties

### DIFF
--- a/contracts/AMM/UniswapV2/Setup.sol
+++ b/contracts/AMM/UniswapV2/Setup.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.6.0;
 import "./uni-v2/UniswapV2ERC20.sol";
 import "./uni-v2/UniswapV2Pair.sol";
 import "./uni-v2/UniswapV2Factory.sol";
+import "./uni-v2/UniswapV2Router01.sol";
 import "./libraries/UniswapV2Library.sol";
+import "./libraries/WETH.sol";
 
 contract Users {
     function proxy(
@@ -19,16 +21,21 @@ contract Setup {
     UniswapV2Pair pair;
     UniswapV2ERC20 testToken1;
     UniswapV2ERC20 testToken2;
+    UniswapV2Router01 router;
+    WETH9 weth;
     Users user;
     bool completed;
 
     constructor() public {
+        weth = new WETH9();
         testToken1 = new UniswapV2ERC20();
         testToken2 = new UniswapV2ERC20();
         factory = new UniswapV2Factory(address(this));
         pair = UniswapV2Pair(
             factory.createPair(address(testToken1), address(testToken2))
         );
+        router = new UniswapV2Router01(address(factory), address(weth));
+
         // Sort the test tokens we just created, for clarity when writing invariant tests later
         (address testTokenA, address testTokenB) = UniswapV2Library.sortTokens(
             address(testToken1),
@@ -50,6 +57,22 @@ contract Setup {
             abi.encodeWithSelector(
                 testToken2.approve.selector,
                 address(pair),
+                uint(-1)
+            )
+        );
+        user.proxy(
+            address(testToken1),
+            abi.encodeWithSelector(
+                testToken1.approve.selector,
+                address(router),
+                uint(-1)
+            )
+        );
+        user.proxy(
+            address(testToken2),
+            abi.encodeWithSelector(
+                testToken2.approve.selector,
+                address(router),
                 uint(-1)
             )
         );

--- a/contracts/AMM/UniswapV2/Setup.sol
+++ b/contracts/AMM/UniswapV2/Setup.sol
@@ -1,9 +1,9 @@
-pragma solidity >=0.5.16;
+pragma solidity ^0.6.0;
 
-import "@uniswap/v2-core/contracts/UniswapV2ERC20.sol";
-import "@uniswap/v2-core/contracts/UniswapV2Pair.sol";
-import "@uniswap/v2-core/contracts/UniswapV2Factory.sol";
-import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
+import "./uni-v2/UniswapV2ERC20.sol";
+import "./uni-v2/UniswapV2Pair.sol";
+import "./uni-v2/UniswapV2Factory.sol";
+import "./libraries/UniswapV2Library.sol";
 
 contract Users {
     function proxy(

--- a/contracts/AMM/UniswapV2/Setup.sol
+++ b/contracts/AMM/UniswapV2/Setup.sol
@@ -1,0 +1,71 @@
+pragma solidity >=0.5.16;
+
+import "@uniswap/v2-core/contracts/UniswapV2ERC20.sol";
+import "@uniswap/v2-core/contracts/UniswapV2Pair.sol";
+import "@uniswap/v2-core/contracts/UniswapV2Factory.sol";
+import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
+
+contract Users {
+    function proxy(
+        address target,
+        bytes memory data
+    ) public returns (bool success, bytes memory retData) {
+        return target.call(data);
+    }
+}
+
+contract Setup {
+    UniswapV2Factory factory;
+    UniswapV2Pair pair;
+    UniswapV2ERC20 testToken1;
+    UniswapV2ERC20 testToken2;
+    Users user;
+    bool completed;
+
+    constructor() public {
+        testToken1 = new UniswapV2ERC20();
+        testToken2 = new UniswapV2ERC20();
+        factory = new UniswapV2Factory(address(this));
+        pair = UniswapV2Pair(
+            factory.createPair(address(testToken1), address(testToken2))
+        );
+        // Sort the test tokens we just created, for clarity when writing invariant tests later
+        (address testTokenA, address testTokenB) = UniswapV2Library.sortTokens(
+            address(testToken1),
+            address(testToken2)
+        );
+        testToken1 = UniswapV2ERC20(testTokenA);
+        testToken2 = UniswapV2ERC20(testTokenB);
+        user = new Users();
+        user.proxy(
+            address(testToken1),
+            abi.encodeWithSelector(
+                testToken1.approve.selector,
+                address(pair),
+                uint(-1)
+            )
+        );
+        user.proxy(
+            address(testToken2),
+            abi.encodeWithSelector(
+                testToken2.approve.selector,
+                address(pair),
+                uint(-1)
+            )
+        );
+    }
+
+    function _init(uint amount1, uint amount2) internal {
+        testToken1.mint(address(user), amount1);
+        testToken2.mint(address(user), amount2);
+        completed = true;
+    }
+
+    function _between(
+        uint val,
+        uint low,
+        uint high
+    ) internal pure returns (uint) {
+        return low + (val % (high - low + 1));
+    }
+}

--- a/contracts/AMM/UniswapV2/UniswapV2PropertyTests.sol
+++ b/contracts/AMM/UniswapV2/UniswapV2PropertyTests.sol
@@ -1,0 +1,208 @@
+pragma solidity >=0.5.0;
+
+import "./Setup.sol";
+import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
+
+contract CryticUniswapV2PropertyTests is Setup {
+    event AmountsIn(uint amount0, uint amount1);
+    event AmountsOut(uint amount0, uint amount1);
+    event BalancesBefore(uint balance0, uint balance1);
+    event BalancesAfter(uint balance0, uint balance1);
+    event ReservesBefore(uint reserve0, uint reserve1);
+    event ReservesAfter(uint reserve0, uint reserve1);
+
+    function testProvideLiquidity(uint amount0, uint amount1) public {
+        // Preconditions:
+        amount0 = _between(amount0, 1000, uint(-1));
+        amount1 = _between(amount1, 1000, uint(-1));
+
+        if (!completed) {
+            _init(amount0, amount1);
+        }
+        //// State before
+        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        uint kBefore = reserve0Before * reserve1Before;
+        //// Transfer tokens to UniswapV2Pair contract
+        (bool success1, ) = user.proxy(
+            address(testToken1),
+            abi.encodeWithSelector(
+                testToken1.transfer.selector,
+                address(pair),
+                amount0
+            )
+        );
+        (bool success2, ) = user.proxy(
+            address(testToken2),
+            abi.encodeWithSelector(
+                testToken2.transfer.selector,
+                address(pair),
+                amount1
+            )
+        );
+        require(success1 && success2);
+
+        // Action:
+        (bool success3, ) = user.proxy(
+            address(pair),
+            abi.encodeWithSelector(
+                bytes4(keccak256("mint(address)")),
+                address(user)
+            )
+        );
+
+        // Postconditions:
+        if (success3) {
+            uint lpTokenBalanceAfter = pair.balanceOf(address(user));
+            (uint reserve0After, uint reserve1After, ) = pair.getReserves();
+            uint kAfter = reserve0After * reserve1After;
+            assert(lpTokenBalanceBefore < lpTokenBalanceAfter);
+            assert(kBefore < kAfter);
+        }
+    }
+
+    function testBadSwap(uint amount0, uint amount1) public {
+        if (!completed) {
+            _init(amount0, amount1);
+        }
+
+        // Preconditions:
+        pair.sync(); // we matched the balances with reserves
+        require(pair.balanceOf(address(user)) > 0); //there is liquidity for the swap
+
+        // Action:
+        (bool success, ) = user.proxy(
+            address(pair),
+            abi.encodeWithSelector(
+                pair.swap.selector,
+                amount0,
+                amount1,
+                address(user),
+                ""
+            )
+        );
+
+        // Post-condition:
+        assert(!success); //call should never succeed
+    }
+
+    function testSwap(uint amount0, uint amount1) public {
+        // Preconditions:
+        if (!completed) {
+            _init(amount0, amount1);
+        }
+        require(pair.balanceOf(address(user)) > 0);
+        require(amount0 > 0 && amount1 > 0);
+
+        uint balance0Before = testToken1.balanceOf(address(user));
+        uint balance1Before = testToken2.balanceOf(address(user));
+
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        uint kBefore = reserve0Before * reserve1Before;
+        emit ReservesBefore(reserve0Before, reserve1Before);
+
+        uint amount0In = _between(amount0, 1, reserve0Before - 1);
+        uint amount1In = _between(amount1, 1, reserve1Before - 1);
+        // emit AmountsIn(amount0In, amount1In);
+        if (amount0In > balance0Before) {
+            testToken1.mint(address(user), amount0In - balance0Before);
+            balance0Before = testToken1.balanceOf(address(user));
+        }
+        if (amount1In > balance1Before) {
+            testToken2.mint(address(user), amount1In - balance1Before);
+            balance1Before = testToken2.balanceOf(address(user));
+        }
+        require(amount0In <= balance0Before || amount1In <= balance1Before);
+        emit BalancesBefore(balance0Before, balance1Before);
+
+        uint amount0Out;
+        uint amount1Out;
+
+        /**
+         * Precondition of UniswapV2Pair.swap is that we transfer the token we are swapping in first.
+         * So, we pick the larger of the two input amounts to transfer, and also use
+         * the Uniswap library to determine how much of the other we will receive in return.
+         */
+        if (amount0In > balance0Before) {
+            amount0In = 0;
+        } else if (amount1In > balance1Before) {
+            amount1In = 0;
+        }
+        if (amount0In > amount1In) {
+            require(amount0In <= balance0Before);
+            amount1In = 0;
+            amount0Out = 0;
+            amount1Out = UniswapV2Library.getAmountOut(
+                amount0In,
+                reserve0Before,
+                reserve1Before
+            );
+            require(amount1Out > 0);
+            emit AmountsIn(amount0In, amount1In);
+            emit AmountsOut(amount0Out, amount1Out);
+            (bool success1, ) = user.proxy(
+                address(testToken1),
+                abi.encodeWithSelector(
+                    testToken1.transfer.selector,
+                    address(pair),
+                    amount0In
+                )
+            );
+            require(success1);
+        } else {
+            require(amount1In <= balance1Before);
+            amount0In = 0;
+            amount1Out = 0;
+            amount0Out = UniswapV2Library.getAmountOut(
+                amount1In,
+                reserve1Before,
+                reserve0Before
+            );
+            require(amount0Out > 0);
+            emit AmountsIn(amount0In, amount1In);
+            emit AmountsOut(amount0Out, amount1Out);
+            (bool success1, ) = user.proxy(
+                address(testToken2),
+                abi.encodeWithSelector(
+                    testToken2.transfer.selector,
+                    address(pair),
+                    amount1In
+                )
+            );
+            require(success1);
+        }
+
+        // Action:
+        (bool success2, ) = user.proxy(
+            address(pair),
+            abi.encodeWithSelector(
+                pair.swap.selector,
+                amount0Out,
+                amount1Out,
+                address(user),
+                ""
+            )
+        );
+
+        // Post-condition:
+        /* 1. Swap should be successful */
+        assert(success2);
+        /* 2. Reserves may change, but k should be (relatively) constant */
+        (uint reserve0After, uint reserve1After, ) = pair.getReserves();
+        uint kAfter = reserve0After * reserve1After;
+        emit ReservesAfter(reserve0After, reserve1After);
+        // assert(kBefore == kAfter);
+        assert(kBefore <= kAfter);
+        /* 3. The change in the user's token balances should match our expectations */
+        uint balance0After = testToken1.balanceOf(address(user));
+        uint balance1After = testToken2.balanceOf(address(user));
+        emit BalancesAfter(balance0After, balance1After);
+        if (amount0In > amount1In) {
+            assert(balance0After == balance0Before - amount0In);
+            assert(balance1After == balance1Before + amount1Out);
+        } else {
+            assert(balance1After == balance1Before - amount1In);
+            assert(balance0After == balance0Before + amount0Out);
+        }
+    }
+}

--- a/contracts/AMM/UniswapV2/UniswapV2PropertyTests.sol
+++ b/contracts/AMM/UniswapV2/UniswapV2PropertyTests.sol
@@ -145,7 +145,6 @@ contract CryticUniswapV2PropertyTests is Setup {
         uint256 amount1
     ) public {
         // State before
-        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
         (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
         uint kBefore = reserve0Before * reserve1Before;
         bool success;

--- a/contracts/AMM/UniswapV2/UniswapV2PropertyTests.sol
+++ b/contracts/AMM/UniswapV2/UniswapV2PropertyTests.sol
@@ -324,6 +324,7 @@ contract CryticUniswapV2PropertyTests is Setup {
     ) public {
         bool success;
         uint lpTokenBalanceBefore = pair.balanceOf(address(user));
+        require(lpTokenBalanceBefore > 0);
 
         UniswapV2ERC20 inToken = zeroForOne ? testToken1 : testToken2;
         uint256 actualAmountIn = _between(
@@ -414,7 +415,10 @@ contract CryticUniswapV2PropertyTests is Setup {
         bool zeroForOne,
         uint256 amount0,
         uint256 amount1
-    ) public {}
+    ) public {
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        require(reserve0Before > 0 && reserve1Before > 0);
+    }
 
     function test_UniV2_swap_IncreaseUserOutBalance(
         bool zeroForOne,
@@ -443,7 +447,9 @@ contract CryticUniswapV2PropertyTests is Setup {
         bool zeroForOne,
         uint256 amountIn
     ) public {
-        bool success;
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        require(reserve0Before > 0 && reserve1Before > 0);
+
         UniswapV2ERC20 inToken = zeroForOne ? testToken1 : testToken2;
         UniswapV2ERC20 outToken = zeroForOne ? testToken2 : testToken1;
 

--- a/contracts/AMM/UniswapV2/UniswapV2PropertyTests.sol
+++ b/contracts/AMM/UniswapV2/UniswapV2PropertyTests.sol
@@ -1,7 +1,7 @@
-pragma solidity >=0.5.0;
+pragma solidity ^0.6.0;
 
 import "./Setup.sol";
-import "@uniswap/v2-periphery/contracts/libraries/UniswapV2Library.sol";
+import "./libraries/UniswapV2Library.sol";
 
 contract CryticUniswapV2PropertyTests is Setup {
     event AmountsIn(uint amount0, uint amount1);

--- a/contracts/AMM/UniswapV2/UniswapV2RouterPropertyTests.sol
+++ b/contracts/AMM/UniswapV2/UniswapV2RouterPropertyTests.sol
@@ -1,0 +1,137 @@
+pragma solidity ^0.6.0;
+
+import "./Setup.sol";
+import "./libraries/UniswapV2Library.sol";
+
+contract CryticUniswapV2RouterPropertyTests is Setup {
+    event AmountsIn(uint amount0, uint amount1);
+    event AmountsOut(uint amount0, uint amount1);
+    event BalancesBefore(uint balance0, uint balance1);
+    event BalancesAfter(uint balance0, uint balance1);
+    event ReservesBefore(uint reserve0, uint reserve1);
+    event ReservesAfter(uint reserve0, uint reserve1);
+    event KValues(uint256 a, uint256 b);
+
+    function _provideLiquidity(
+        uint256 amount0,
+        uint256 amount1
+    ) internal returns (uint256, uint256, bool) {
+
+    }
+
+    function _burnLiquidity(
+        uint256 amount,
+        uint256 balance
+    ) internal returns (uint256, bool) {
+
+    }
+
+    function _swap(bool zeroForOne, uint256 amount0, uint256 amount1) internal returns(bool) {
+
+    }
+
+    // Providing liquidity
+
+    function test_UniV2_provideLiquidity_IncreasesK(
+        uint256 amount0,
+        uint256 amount1
+    ) public {
+ 
+    }
+
+    function test_UniV2_provideLiquidity_IncreasesLPSupply(
+        uint256 amount0,
+        uint256 amount1
+    ) public {
+
+    }
+
+    // Fails on unbalanced liquidity? TODO
+    /*     function test_UniV2_provideLiquidity_tokenPriceUnchanged(
+        uint256 amount0,
+        uint256 amount1,
+        uint256 amountIn0,
+        uint256 amountIn1
+    ) public {
+        bool success;
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        amountIn0 = _between(amountIn0, 1, reserve0Before);
+        amountIn1 = _between(amountIn1, 1, reserve1Before);
+
+        uint256 amountOut1Before = UniswapV2Library.quote(
+            amountIn0,
+            reserve0Before,
+            reserve1Before
+        );
+        uint256 amountOut0Before = UniswapV2Library.quote(
+            amountIn1,
+            reserve1Before,
+            reserve0Before
+        );
+
+        (amount0, amount1, success) = _provideLiquidity(amount0, amount1);
+
+        if (success) {
+            (uint reserve0After, uint reserve1After, ) = pair.getReserves();
+            uint256 amountOut1After = UniswapV2Library.quote(
+                amountIn0,
+                reserve0After,
+                reserve1After
+            );
+            uint256 amountOut0After = UniswapV2Library.quote(
+                amountIn1,
+                reserve1After,
+                reserve0After
+            );
+            emit AmountsIn(amountOut1After, amountOut1Before);
+            emit AmountsIn(amountOut0After, amountOut0Before);
+            assert(amountOut1After == amountOut1Before);
+            assert(amountOut0After == amountOut0Before);
+        }
+    } */
+
+    function test_UniV2_provideLiquidity_IncreaseReserves(
+        uint256 amount0,
+        uint256 amount1
+    ) public {
+
+    }
+
+    function test_UniV2_provideLiquidity_IncreaseUserLPBalance(
+        uint256 amount0,
+        uint256 amount1
+    ) public {
+
+    }
+
+    // Removing liquidity
+
+    function test_UniV2_removeLiquidity_DecreaseK(uint256 amount) public {
+
+    }
+
+    function test_UniV2_removeLiquidity_DecreaseLPSupply(uint256 amount) public {
+
+    }
+    // TODO
+    function test_UniV2_removeLiquidity_tokenPriceUnchanged(uint256 amount) public {}
+
+    function test_UniV2_removeLiquidity_DecreaseReserves(uint256 amount) public {
+
+    }
+
+    function test_UniV2_removeLiquidity_DecreaseUserLPBalance(uint256 amount) public {
+
+    }
+
+    // Swapping
+    function test_UniV2_swap_DoesNotDecreaseK(bool zeroForOne, uint256 amount0, uint256 amount1) public {
+
+    }
+
+    function test_UniV2_swap_PathIndependence() public {}
+
+    function test_UniV2_swap_IncreaseUserOutBalance() public {}
+
+    function test_UniV2_swap_OutPriceIncrease_InPriceDecrease() public {}
+}

--- a/contracts/AMM/UniswapV2/UniswapV2RouterPropertyTests.sol
+++ b/contracts/AMM/UniswapV2/UniswapV2RouterPropertyTests.sol
@@ -320,7 +320,7 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         }
     }
 
-    function test_UniV2_swapExactTokensForTokens_PathIndependence(
+    function test_UniV2_swapExactTokensForTokens_TwoWaySwapDoesNotResultInProfit(
         bool zeroForOne,
         uint256 amountIn,
         uint256 amountOutMin

--- a/contracts/AMM/UniswapV2/UniswapV2RouterPropertyTests.sol
+++ b/contracts/AMM/UniswapV2/UniswapV2RouterPropertyTests.sol
@@ -18,29 +18,97 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amount1,
         uint256 amount0Min,
         uint256 amount1Min
-    ) internal returns (uint256, uint256, bool) {
+    ) internal returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
         amount0 = _between(amount0, 1000, uint(-1));
         amount1 = _between(amount1, 1000, uint(-1));
         amount0Min = _between(amount0Min, 0, amount0);
         amount1Min = _between(amount1Min, 0, amount1);
-        uint256 deadline = block.timestamp + 1000;
+        uint256 deadline = block.timestamp.add(1000);
 
         if (!completed) {
             _init(amount0, amount1);
         }
 
-        router.addLiquidity(address(testToken1), address(testToken2), amount0, amount1, amount0Min, amount1Min, address(user), deadline);
+        hevm.prank(address(user));
+        (amountA, amountB, liquidity) = router.addLiquidity(
+            address(testToken1),
+            address(testToken2),
+            amount0,
+            amount1,
+            amount0Min,
+            amount1Min,
+            address(user),
+            deadline
+        );
     }
 
     function _burnLiquidity(
         uint256 amount,
-        uint256 balance
-    ) internal returns (uint256, bool) {
+        uint256 amount0Min,
+        uint256 amount1Min
+    ) internal returns (uint256 amount0, uint256 amount1) {
+        uint256 balance = pair.balanceOf(address(user));
+        (uint reserve0, uint reserve1, ) = pair.getReserves();
 
+        amount = _between(amount, 1, balance);
+        amount0Min = _between(amount0Min, 0, reserve0);
+        amount1Min = _between(amount1Min, 0, reserve1);
+        uint256 deadline = block.timestamp.add(1000);
+
+        hevm.prank(address(user));
+        (amount0, amount1) = router.removeLiquidity(
+            address(testToken1),
+            address(testToken2),
+            amount,
+            amount0Min,
+            amount1Min,
+            address(user),
+            deadline
+        );
     }
 
-    function _swap(bool zeroForOne, uint256 amount0, uint256 amount1) internal returns(bool) {
+    function _swapExactTokensForTokens(
+        bool zeroForOne,
+        uint256 amountIn,
+        uint256 amountOutMin
+    ) internal returns (uint[] memory amounts) {
+        (uint reserve0, uint reserve1, ) = pair.getReserves();
 
+        address[] memory path = new address[](2);
+        path[0] = zeroForOne ? address(testToken1) : address(testToken2);
+        path[1] = zeroForOne ? address(testToken2) : address(testToken1);
+        uint256 deadline = block.timestamp.add(1000);
+        amountIn = _between(
+            amountIn,
+            1,
+            UniswapV2ERC20(path[0]).balanceOf(address(user))
+        );
+        amountOutMin = _between(
+            amountOutMin,
+            0,
+            zeroForOne ? reserve1 : reserve0
+        );
+
+        hevm.prank(address(user));
+        amounts = router.swapExactTokensForTokens(
+            amountIn,
+            amountOutMin,
+            path,
+            address(user),
+            deadline
+        );
+    }
+
+    function _getTokenPrice(
+        bool zeroForOne,
+        uint256 inputAmount
+    ) internal returns (uint256 amountOut) {
+        (uint reserve0, uint reserve1, ) = pair.getReserves();
+        amountOut = router.getAmountOut(
+            inputAmount,
+            zeroForOne ? reserve0 : reserve1,
+            zeroForOne ? reserve1 : reserve0
+        );
     }
 
     // Providing liquidity
@@ -52,12 +120,12 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amount1Min
     ) public {
         (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
-        uint kBefore = reserve0Before * reserve1Before;
+        uint kBefore = reserve0Before.mul(reserve1Before);
 
         _provideLiquidity(amount0, amount1, amount0Min, amount1Min);
 
         (uint reserve0After, uint reserve1After, ) = pair.getReserves();
-        uint kAfter = reserve0After * reserve1After;
+        uint kAfter = reserve0After.mul(reserve1After);
         if (kBefore >= kAfter) {
             emit AssertionFailed(kBefore, kAfter, "kBefore is >= kAfter");
         }
@@ -65,97 +133,241 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
 
     function test_UniV2_provideLiquidity_IncreasesLPSupply(
         uint256 amount0,
-        uint256 amount1
+        uint256 amount1,
+        uint256 amount0Min,
+        uint256 amount1Min
     ) public {
-        emit AssertionFailed(0, 9, "Test");
+        // State before
+        uint256 lpTokenSupplyBefore = pair.totalSupply();
+
+        _provideLiquidity(amount0, amount1, amount0Min, amount1Min);
+
+        // Postconditions:
+        uint256 lpTokenSupplyAfter = pair.totalSupply();
+        assert(lpTokenSupplyBefore < lpTokenSupplyAfter);
     }
 
-    // Fails on unbalanced liquidity? TODO
-    /*     function test_UniV2_provideLiquidity_tokenPriceUnchanged(
+    function test_UniV2_provideLiquidity_tokenPriceUnchanged(
         uint256 amount0,
         uint256 amount1,
-        uint256 amountIn0,
-        uint256 amountIn1
+        uint256 amount0Min,
+        uint256 amount1Min,
+        bool zeroForOne,
+        uint256 amountIn
     ) public {
-        bool success;
-        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
-        amountIn0 = _between(amountIn0, 1, reserve0Before);
-        amountIn1 = _between(amountIn1, 1, reserve1Before);
-
-        uint256 amountOut1Before = UniswapV2Library.quote(
-            amountIn0,
-            reserve0Before,
-            reserve1Before
+        UniswapV2ERC20 inToken = zeroForOne ? testToken1 : testToken2;
+        uint256 actualAmountIn = _between(
+            amountIn,
+            1,
+            inToken.balanceOf(address(user))
         );
-        uint256 amountOut0Before = UniswapV2Library.quote(
-            amountIn1,
-            reserve1Before,
-            reserve0Before
-        );
+        uint256 amountOutBefore = _getTokenPrice(zeroForOne, actualAmountIn);
 
-        (amount0, amount1, success) = _provideLiquidity(amount0, amount1);
+        _provideLiquidity(amount0, amount1, amount0Min, amount1Min);
 
-        if (success) {
-            (uint reserve0After, uint reserve1After, ) = pair.getReserves();
-            uint256 amountOut1After = UniswapV2Library.quote(
-                amountIn0,
-                reserve0After,
-                reserve1After
-            );
-            uint256 amountOut0After = UniswapV2Library.quote(
-                amountIn1,
-                reserve1After,
-                reserve0After
-            );
-            emit AmountsIn(amountOut1After, amountOut1Before);
-            emit AmountsIn(amountOut0After, amountOut0Before);
-            assert(amountOut1After == amountOut1Before);
-            assert(amountOut0After == amountOut0Before);
-        }
-    } */
+        uint256 amountOutAfter = _getTokenPrice(zeroForOne, actualAmountIn);
+
+        emit AmountsIn(amountOutBefore, amountOutAfter);
+        assert(amountOutBefore == amountOutAfter);
+    }
 
     function test_UniV2_provideLiquidity_IncreaseReserves(
         uint256 amount0,
-        uint256 amount1
+        uint256 amount1,
+        uint256 amount0Min,
+        uint256 amount1Min
     ) public {
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
 
+        _provideLiquidity(amount0, amount1, amount0Min, amount1Min);
+
+        // Postconditions:
+        (uint reserve0After, uint reserve1After, ) = pair.getReserves();
+
+        assert(reserve0Before < reserve0After);
+        assert(reserve1Before < reserve1After);
     }
 
     function test_UniV2_provideLiquidity_IncreaseUserLPBalance(
         uint256 amount0,
-        uint256 amount1
+        uint256 amount1,
+        uint256 amount0Min,
+        uint256 amount1Min
     ) public {
+        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
 
+        _provideLiquidity(amount0, amount1, amount0Min, amount1Min);
+
+        uint lpTokenBalanceAfter = pair.balanceOf(address(user));
+        assert(lpTokenBalanceBefore < lpTokenBalanceAfter);
     }
 
     // Removing liquidity
 
-    function test_UniV2_removeLiquidity_DecreaseK(uint256 amount) public {
+    function test_UniV2_removeLiquidity_DecreaseK(
+        uint256 amount,
+        uint256 amount0Min,
+        uint256 amount1Min
+    ) public {
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        uint kBefore = reserve0Before.mul(reserve1Before);
 
+        _burnLiquidity(amount, amount0Min, amount1Min);
+
+        (uint reserve0After, uint reserve1After, ) = pair.getReserves();
+        uint kAfter = reserve0After.mul(reserve1After);
+        if (kBefore <= kAfter) {
+            emit AssertionFailed(kBefore, kAfter, "kBefore is <= kAfter");
+        }
     }
 
-    function test_UniV2_removeLiquidity_DecreaseLPSupply(uint256 amount) public {
+    function test_UniV2_removeLiquidity_DecreaseLPSupply(
+        uint256 amount,
+        uint256 amount0Min,
+        uint256 amount1Min
+    ) public {
+        // State before
+        uint256 lpTokenSupplyBefore = pair.totalSupply();
 
+        _burnLiquidity(amount, amount0Min, amount1Min);
+
+        // Postconditions:
+        uint256 lpTokenSupplyAfter = pair.totalSupply();
+        assert(lpTokenSupplyBefore > lpTokenSupplyAfter);
     }
-    // TODO
-    function test_UniV2_removeLiquidity_tokenPriceUnchanged(uint256 amount) public {}
 
-    function test_UniV2_removeLiquidity_DecreaseReserves(uint256 amount) public {
+    function test_UniV2_removeLiquidity_tokenPriceUnchanged(
+        uint256 amount,
+        uint256 amount0Min,
+        uint256 amount1Min,
+        bool zeroForOne,
+        uint256 amountIn
+    ) public {
+        UniswapV2ERC20 inToken = zeroForOne ? testToken1 : testToken2;
+        uint256 actualAmountIn = _between(
+            amountIn,
+            1,
+            inToken.balanceOf(address(user))
+        );
+        uint256 amountOutBefore = _getTokenPrice(zeroForOne, actualAmountIn);
 
+        _burnLiquidity(amount, amount0Min, amount1Min);
+
+        uint256 amountOutAfter = _getTokenPrice(zeroForOne, actualAmountIn);
+
+        emit AmountsIn(amountOutBefore, amountOutAfter);
+        assert(amountOutBefore == amountOutAfter);
     }
 
-    function test_UniV2_removeLiquidity_DecreaseUserLPBalance(uint256 amount) public {
+    function test_UniV2_removeLiquidity_DecreaseReserves(
+        uint256 amount,
+        uint256 amount0Min,
+        uint256 amount1Min
+    ) public {
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
 
+        _burnLiquidity(amount, amount0Min, amount1Min);
+
+        // Postconditions:
+        (uint reserve0After, uint reserve1After, ) = pair.getReserves();
+
+        assert(reserve0Before > reserve0After);
+        assert(reserve1Before > reserve1After);
+    }
+
+    function test_UniV2_removeLiquidity_DecreaseUserLPBalance(
+        uint256 amount,
+        uint256 amount0Min,
+        uint256 amount1Min
+    ) public {
+        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
+
+        _burnLiquidity(amount, amount0Min, amount1Min);
+
+        uint lpTokenBalanceAfter = pair.balanceOf(address(user));
+        assert(lpTokenBalanceBefore > lpTokenBalanceAfter);
     }
 
     // Swapping
-    function test_UniV2_swap_DoesNotDecreaseK(bool zeroForOne, uint256 amount0, uint256 amount1) public {
+    function test_UniV2_swapExactTokensForTokens_DoesNotDecreaseK(
+        bool zeroForOne,
+        uint256 amountIn,
+        uint256 amountOutMin
+    ) public {
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        uint kBefore = reserve0Before.mul(reserve1Before);
 
+        _swapExactTokensForTokens(zeroForOne, amountIn, amountOutMin);
+
+        (uint reserve0After, uint reserve1After, ) = pair.getReserves();
+        uint kAfter = reserve0After.mul(reserve1After);
+        if (kBefore > kAfter) {
+            emit AssertionFailed(kBefore, kAfter, "kBefore is > kAfter");
+        }
     }
 
-    function test_UniV2_swap_PathIndependence() public {}
+    function test_UniV2_swapExactTokensForTokens_PathIndependence(
+        bool zeroForOne,
+        uint256 amountIn,
+        uint256 amountOutMin
+    ) public {
+        uint256 balanceBefore0 = testToken1.balanceOf(address(user));
+        uint256 balanceBefore1 = testToken2.balanceOf(address(user));
+        uint256[] memory amounts = new uint256[](2);
 
-    function test_UniV2_swap_IncreaseUserOutBalance() public {}
+        amounts = _swapExactTokensForTokens(zeroForOne, amountIn, amountOutMin);
+        _swapExactTokensForTokens(!zeroForOne, amounts[1], 0);
 
-    function test_UniV2_swap_OutPriceIncrease_InPriceDecrease() public {}
+        uint256 balanceAfter0 = testToken1.balanceOf(address(user));
+        uint256 balanceAfter1 = testToken2.balanceOf(address(user));
+
+        assert(balanceAfter0 <= balanceBefore0);
+        assert(balanceAfter1 <= balanceBefore1);
+    }
+
+    function test_UniV2_swapExactTokensForTokens_IncreaseUserOutBalance(
+        bool zeroForOne,
+        uint256 amountIn,
+        uint256 amountOutMin
+    ) public {
+        UniswapV2ERC20 outToken = zeroForOne ? testToken2 : testToken1;
+        uint256 balanceBefore = outToken.balanceOf(address(user));
+
+        _swapExactTokensForTokens(zeroForOne, amountIn, amountOutMin);
+
+        uint256 balanceAfter = outToken.balanceOf(address(user));
+        assert(balanceAfter > balanceBefore);
+    }
+
+    function test_UniV2_swapExactTokensForTokens_OutPriceIncrease_InPriceDecrease(
+        bool zeroForOne,
+        uint256 amountIn,
+        uint256 amountOutMin
+    ) public {
+        UniswapV2ERC20 inToken = zeroForOne ? testToken1 : testToken2;
+        UniswapV2ERC20 outToken = zeroForOne ? testToken2 : testToken1;
+
+        uint256 actualAmountIn0 = _between(
+            amountIn,
+            1,
+            inToken.balanceOf(address(user))
+        );
+        uint256 actualAmountIn1 = _between(
+            amountIn,
+            1,
+            outToken.balanceOf(address(user))
+        );
+        uint256 amountOut1Before = _getTokenPrice(zeroForOne, actualAmountIn0);
+        uint256 amountOut0Before = _getTokenPrice(!zeroForOne, actualAmountIn1);
+
+        _swapExactTokensForTokens(zeroForOne, amountIn, amountOutMin);
+
+        uint256 amountOut1After = _getTokenPrice(zeroForOne, actualAmountIn0);
+        uint256 amountOut0After = _getTokenPrice(!zeroForOne, actualAmountIn1);
+
+        assert(amountOut1Before > amountOut1After);
+        assert(amountOut0Before < amountOut0After);
+    }
+
+    fallback() external payable {}
 }

--- a/contracts/AMM/UniswapV2/UniswapV2RouterPropertyTests.sol
+++ b/contracts/AMM/UniswapV2/UniswapV2RouterPropertyTests.sol
@@ -209,6 +209,9 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amount0Min,
         uint256 amount1Min
     ) public {
+        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
+        require(lpTokenBalanceBefore > 0);
+
         (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
         uint kBefore = reserve0Before.mul(reserve1Before);
 
@@ -226,6 +229,9 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amount0Min,
         uint256 amount1Min
     ) public {
+        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
+        require(lpTokenBalanceBefore > 0);
+
         // State before
         uint256 lpTokenSupplyBefore = pair.totalSupply();
 
@@ -243,6 +249,9 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         bool zeroForOne,
         uint256 amountIn
     ) public {
+        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
+        require(lpTokenBalanceBefore > 0);
+
         UniswapV2ERC20 inToken = zeroForOne ? testToken1 : testToken2;
         uint256 actualAmountIn = _between(
             amountIn,
@@ -264,6 +273,9 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amount0Min,
         uint256 amount1Min
     ) public {
+        uint lpTokenBalanceBefore = pair.balanceOf(address(user));
+        require(lpTokenBalanceBefore > 0);
+
         (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
 
         _burnLiquidity(amount, amount0Min, amount1Min);
@@ -281,6 +293,7 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amount1Min
     ) public {
         uint lpTokenBalanceBefore = pair.balanceOf(address(user));
+        require(lpTokenBalanceBefore > 0);
 
         _burnLiquidity(amount, amount0Min, amount1Min);
 
@@ -295,6 +308,7 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amountOutMin
     ) public {
         (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        require(reserve0Before > 0 && reserve1Before > 0);
         uint kBefore = reserve0Before.mul(reserve1Before);
 
         _swapExactTokensForTokens(zeroForOne, amountIn, amountOutMin);
@@ -311,6 +325,9 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amountIn,
         uint256 amountOutMin
     ) public {
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        require(reserve0Before > 0 && reserve1Before > 0);
+
         uint256 balanceBefore0 = testToken1.balanceOf(address(user));
         uint256 balanceBefore1 = testToken2.balanceOf(address(user));
         uint256[] memory amounts = new uint256[](2);
@@ -330,6 +347,9 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amountIn,
         uint256 amountOutMin
     ) public {
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        require(reserve0Before > 0 && reserve1Before > 0);
+
         UniswapV2ERC20 outToken = zeroForOne ? testToken2 : testToken1;
         uint256 balanceBefore = outToken.balanceOf(address(user));
 
@@ -344,6 +364,9 @@ contract CryticUniswapV2RouterPropertyTests is Setup {
         uint256 amountIn,
         uint256 amountOutMin
     ) public {
+        (uint reserve0Before, uint reserve1Before, ) = pair.getReserves();
+        require(reserve0Before > 0 && reserve1Before > 0);
+        
         UniswapV2ERC20 inToken = zeroForOne ? testToken1 : testToken2;
         UniswapV2ERC20 outToken = zeroForOne ? testToken2 : testToken1;
 

--- a/contracts/AMM/UniswapV2/echidna-config.yaml
+++ b/contracts/AMM/UniswapV2/echidna-config.yaml
@@ -1,4 +1,4 @@
 testMode: assertion 
 corpusDir: corpus
 seqLen: 25
-testLimit: 10000
+testLimit: 100000

--- a/contracts/AMM/UniswapV2/echidna-config.yaml
+++ b/contracts/AMM/UniswapV2/echidna-config.yaml
@@ -1,4 +1,4 @@
-testMode: assertion 
+testMode: assertion
 corpusDir: corpus
 seqLen: 25
 testLimit: 100000

--- a/contracts/AMM/UniswapV2/echidna-config.yaml
+++ b/contracts/AMM/UniswapV2/echidna-config.yaml
@@ -1,0 +1,4 @@
+testMode: assertion 
+corpusDir: corpus
+seqLen: 25
+testLimit: 10000

--- a/contracts/AMM/UniswapV2/interfaces/IERC20.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IERC20.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.5.0;
+
+interface IERC20 {
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function decimals() external view returns (uint8);
+    function totalSupply() external view returns (uint);
+    function balanceOf(address owner) external view returns (uint);
+    function allowance(address owner, address spender) external view returns (uint);
+
+    function approve(address spender, uint value) external returns (bool);
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(address from, address to, uint value) external returns (bool);
+}

--- a/contracts/AMM/UniswapV2/interfaces/IERC20.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IERC20.sol
@@ -5,13 +5,27 @@ interface IERC20 {
     event Transfer(address indexed from, address indexed to, uint value);
 
     function name() external view returns (string memory);
+
     function symbol() external view returns (string memory);
+
     function decimals() external view returns (uint8);
+
     function totalSupply() external view returns (uint);
+
     function balanceOf(address owner) external view returns (uint);
-    function allowance(address owner, address spender) external view returns (uint);
+
+    function allowance(
+        address owner,
+        address spender
+    ) external view returns (uint);
 
     function approve(address spender, uint value) external returns (bool);
+
     function transfer(address to, uint value) external returns (bool);
-    function transferFrom(address from, address to, uint value) external returns (bool);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint value
+    ) external returns (bool);
 }

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Callee.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Callee.sol
@@ -1,0 +1,5 @@
+pragma solidity >=0.5.0;
+
+interface IUniswapV2Callee {
+    function uniswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data) external;
+}

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Callee.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Callee.sol
@@ -1,5 +1,10 @@
 pragma solidity >=0.5.0;
 
 interface IUniswapV2Callee {
-    function uniswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data) external;
+    function uniswapV2Call(
+        address sender,
+        uint amount0,
+        uint amount1,
+        bytes calldata data
+    ) external;
 }

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2ERC20.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2ERC20.sol
@@ -1,0 +1,23 @@
+pragma solidity >=0.5.0;
+
+interface IUniswapV2ERC20 {
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    function name() external pure returns (string memory);
+    function symbol() external pure returns (string memory);
+    function decimals() external pure returns (uint8);
+    function totalSupply() external view returns (uint);
+    function balanceOf(address owner) external view returns (uint);
+    function allowance(address owner, address spender) external view returns (uint);
+
+    function approve(address spender, uint value) external returns (bool);
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(address from, address to, uint value) external returns (bool);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+    function nonces(address owner) external view returns (uint);
+
+    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+}

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2ERC20.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2ERC20.sol
@@ -5,19 +5,43 @@ interface IUniswapV2ERC20 {
     event Transfer(address indexed from, address indexed to, uint value);
 
     function name() external pure returns (string memory);
+
     function symbol() external pure returns (string memory);
+
     function decimals() external pure returns (uint8);
+
     function totalSupply() external view returns (uint);
+
     function balanceOf(address owner) external view returns (uint);
-    function allowance(address owner, address spender) external view returns (uint);
+
+    function allowance(
+        address owner,
+        address spender
+    ) external view returns (uint);
 
     function approve(address spender, uint value) external returns (bool);
+
     function transfer(address to, uint value) external returns (bool);
-    function transferFrom(address from, address to, uint value) external returns (bool);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint value
+    ) external returns (bool);
 
     function DOMAIN_SEPARATOR() external view returns (bytes32);
+
     function PERMIT_TYPEHASH() external pure returns (bytes32);
+
     function nonces(address owner) external view returns (uint);
 
-    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function permit(
+        address owner,
+        address spender,
+        uint value,
+        uint deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
 }

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Factory.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Factory.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.5.0;
+
+interface IUniswapV2Factory {
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint);
+
+    function feeTo() external view returns (address);
+    function feeToSetter() external view returns (address);
+
+    function getPair(address tokenA, address tokenB) external view returns (address pair);
+    function allPairs(uint) external view returns (address pair);
+    function allPairsLength() external view returns (uint);
+
+    function createPair(address tokenA, address tokenB) external returns (address pair);
+
+    function setFeeTo(address) external;
+    function setFeeToSetter(address) external;
+}

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Factory.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Factory.sol
@@ -1,17 +1,32 @@
 pragma solidity >=0.5.0;
 
 interface IUniswapV2Factory {
-    event PairCreated(address indexed token0, address indexed token1, address pair, uint);
+    event PairCreated(
+        address indexed token0,
+        address indexed token1,
+        address pair,
+        uint
+    );
 
     function feeTo() external view returns (address);
+
     function feeToSetter() external view returns (address);
 
-    function getPair(address tokenA, address tokenB) external view returns (address pair);
+    function getPair(
+        address tokenA,
+        address tokenB
+    ) external view returns (address pair);
+
     function allPairs(uint) external view returns (address pair);
+
     function allPairsLength() external view returns (uint);
 
-    function createPair(address tokenA, address tokenB) external returns (address pair);
+    function createPair(
+        address tokenA,
+        address tokenB
+    ) external returns (address pair);
 
     function setFeeTo(address) external;
+
     function setFeeToSetter(address) external;
 }

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Pair.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Pair.sol
@@ -1,0 +1,52 @@
+pragma solidity >=0.5.0;
+
+interface IUniswapV2Pair {
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    function name() external pure returns (string memory);
+    function symbol() external pure returns (string memory);
+    function decimals() external pure returns (uint8);
+    function totalSupply() external view returns (uint);
+    function balanceOf(address owner) external view returns (uint);
+    function allowance(address owner, address spender) external view returns (uint);
+
+    function approve(address spender, uint value) external returns (bool);
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(address from, address to, uint value) external returns (bool);
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+    function PERMIT_TYPEHASH() external pure returns (bytes32);
+    function nonces(address owner) external view returns (uint);
+
+    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+
+    event Mint(address indexed sender, uint amount0, uint amount1);
+    event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
+    event Swap(
+        address indexed sender,
+        uint amount0In,
+        uint amount1In,
+        uint amount0Out,
+        uint amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function MINIMUM_LIQUIDITY() external pure returns (uint);
+    function factory() external view returns (address);
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    function price0CumulativeLast() external view returns (uint);
+    function price1CumulativeLast() external view returns (uint);
+    function kLast() external view returns (uint);
+
+    function mint(address to) external returns (uint liquidity);
+    function burn(address to) external returns (uint amount0, uint amount1);
+    function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
+    function skim(address to) external;
+    function sync() external;
+
+    function initialize(address, address) external;
+}

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Pair.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Pair.sol
@@ -5,24 +5,53 @@ interface IUniswapV2Pair {
     event Transfer(address indexed from, address indexed to, uint value);
 
     function name() external pure returns (string memory);
+
     function symbol() external pure returns (string memory);
+
     function decimals() external pure returns (uint8);
+
     function totalSupply() external view returns (uint);
+
     function balanceOf(address owner) external view returns (uint);
-    function allowance(address owner, address spender) external view returns (uint);
+
+    function allowance(
+        address owner,
+        address spender
+    ) external view returns (uint);
 
     function approve(address spender, uint value) external returns (bool);
+
     function transfer(address to, uint value) external returns (bool);
-    function transferFrom(address from, address to, uint value) external returns (bool);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint value
+    ) external returns (bool);
 
     function DOMAIN_SEPARATOR() external view returns (bytes32);
+
     function PERMIT_TYPEHASH() external pure returns (bytes32);
+
     function nonces(address owner) external view returns (uint);
 
-    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function permit(
+        address owner,
+        address spender,
+        uint value,
+        uint deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
 
     event Mint(address indexed sender, uint amount0, uint amount1);
-    event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
+    event Burn(
+        address indexed sender,
+        uint amount0,
+        uint amount1,
+        address indexed to
+    );
     event Swap(
         address indexed sender,
         uint amount0In,
@@ -34,18 +63,37 @@ interface IUniswapV2Pair {
     event Sync(uint112 reserve0, uint112 reserve1);
 
     function MINIMUM_LIQUIDITY() external pure returns (uint);
+
     function factory() external view returns (address);
+
     function token0() external view returns (address);
+
     function token1() external view returns (address);
-    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+
+    function getReserves()
+        external
+        view
+        returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+
     function price0CumulativeLast() external view returns (uint);
+
     function price1CumulativeLast() external view returns (uint);
+
     function kLast() external view returns (uint);
 
     function mint(address to) external returns (uint liquidity);
+
     function burn(address to) external returns (uint amount0, uint amount1);
-    function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
+
+    function swap(
+        uint amount0Out,
+        uint amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+
     function skim(address to) external;
+
     function sync() external;
 
     function initialize(address, address) external;

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Router01.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Router01.sol
@@ -1,0 +1,95 @@
+pragma solidity >=0.6.2;
+
+interface IUniswapV2Router01 {
+    function factory() external pure returns (address);
+    function WETH() external pure returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB, uint liquidity);
+    function addLiquidityETH(
+        address token,
+        uint amountTokenDesired,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external payable returns (uint amountToken, uint amountETH, uint liquidity);
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountA, uint amountB);
+    function removeLiquidityETH(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountToken, uint amountETH);
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountA, uint amountB);
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountToken, uint amountETH);
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+    function swapTokensForExactTokens(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        payable
+        returns (uint[] memory amounts);
+    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+        external
+        returns (uint[] memory amounts);
+    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        returns (uint[] memory amounts);
+    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+        external
+        payable
+        returns (uint[] memory amounts);
+
+    function quote(uint amountA, uint reserveA, uint reserveB) external pure returns (uint amountB);
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) external pure returns (uint amountOut);
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) external pure returns (uint amountIn);
+    function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts);
+    function getAmountsIn(uint amountOut, address[] calldata path) external view returns (uint[] memory amounts);
+}

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Router01.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Router01.sol
@@ -2,6 +2,7 @@ pragma solidity >=0.6.2;
 
 interface IUniswapV2Router01 {
     function factory() external pure returns (address);
+
     function WETH() external pure returns (address);
 
     function addLiquidity(
@@ -14,6 +15,7 @@ interface IUniswapV2Router01 {
         address to,
         uint deadline
     ) external returns (uint amountA, uint amountB, uint liquidity);
+
     function addLiquidityETH(
         address token,
         uint amountTokenDesired,
@@ -21,7 +23,11 @@ interface IUniswapV2Router01 {
         uint amountETHMin,
         address to,
         uint deadline
-    ) external payable returns (uint amountToken, uint amountETH, uint liquidity);
+    )
+        external
+        payable
+        returns (uint amountToken, uint amountETH, uint liquidity);
+
     function removeLiquidity(
         address tokenA,
         address tokenB,
@@ -31,6 +37,7 @@ interface IUniswapV2Router01 {
         address to,
         uint deadline
     ) external returns (uint amountA, uint amountB);
+
     function removeLiquidityETH(
         address token,
         uint liquidity,
@@ -39,6 +46,7 @@ interface IUniswapV2Router01 {
         address to,
         uint deadline
     ) external returns (uint amountToken, uint amountETH);
+
     function removeLiquidityWithPermit(
         address tokenA,
         address tokenB,
@@ -47,8 +55,12 @@ interface IUniswapV2Router01 {
         uint amountBMin,
         address to,
         uint deadline,
-        bool approveMax, uint8 v, bytes32 r, bytes32 s
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
     ) external returns (uint amountA, uint amountB);
+
     function removeLiquidityETHWithPermit(
         address token,
         uint liquidity,
@@ -56,8 +68,12 @@ interface IUniswapV2Router01 {
         uint amountETHMin,
         address to,
         uint deadline,
-        bool approveMax, uint8 v, bytes32 r, bytes32 s
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
     ) external returns (uint amountToken, uint amountETH);
+
     function swapExactTokensForTokens(
         uint amountIn,
         uint amountOutMin,
@@ -65,6 +81,7 @@ interface IUniswapV2Router01 {
         address to,
         uint deadline
     ) external returns (uint[] memory amounts);
+
     function swapTokensForExactTokens(
         uint amountOut,
         uint amountInMax,
@@ -72,24 +89,62 @@ interface IUniswapV2Router01 {
         address to,
         uint deadline
     ) external returns (uint[] memory amounts);
-    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
-        external
-        payable
-        returns (uint[] memory amounts);
-    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
-        external
-        returns (uint[] memory amounts);
-    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
-        external
-        returns (uint[] memory amounts);
-    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
-        external
-        payable
-        returns (uint[] memory amounts);
 
-    function quote(uint amountA, uint reserveA, uint reserveB) external pure returns (uint amountB);
-    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) external pure returns (uint amountOut);
-    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) external pure returns (uint amountIn);
-    function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts);
-    function getAmountsIn(uint amountOut, address[] calldata path) external view returns (uint[] memory amounts);
+    function swapExactETHForTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable returns (uint[] memory amounts);
+
+    function swapTokensForExactETH(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function swapExactTokensForETH(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+
+    function swapETHForExactTokens(
+        uint amountOut,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable returns (uint[] memory amounts);
+
+    function quote(
+        uint amountA,
+        uint reserveA,
+        uint reserveB
+    ) external pure returns (uint amountB);
+
+    function getAmountOut(
+        uint amountIn,
+        uint reserveIn,
+        uint reserveOut
+    ) external pure returns (uint amountOut);
+
+    function getAmountIn(
+        uint amountOut,
+        uint reserveIn,
+        uint reserveOut
+    ) external pure returns (uint amountIn);
+
+    function getAmountsOut(
+        uint amountIn,
+        address[] calldata path
+    ) external view returns (uint[] memory amounts);
+
+    function getAmountsIn(
+        uint amountOut,
+        address[] calldata path
+    ) external view returns (uint[] memory amounts);
 }

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Router02.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Router02.sol
@@ -1,0 +1,44 @@
+pragma solidity >=0.6.2;
+
+import './IUniswapV2Router01.sol';
+
+interface IUniswapV2Router02 is IUniswapV2Router01 {
+    function removeLiquidityETHSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external returns (uint amountETH);
+    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external returns (uint amountETH);
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external payable;
+    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external;
+}

--- a/contracts/AMM/UniswapV2/interfaces/IUniswapV2Router02.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IUniswapV2Router02.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.6.2;
 
-import './IUniswapV2Router01.sol';
+import "./IUniswapV2Router01.sol";
 
 interface IUniswapV2Router02 is IUniswapV2Router01 {
     function removeLiquidityETHSupportingFeeOnTransferTokens(
@@ -11,6 +11,7 @@ interface IUniswapV2Router02 is IUniswapV2Router01 {
         address to,
         uint deadline
     ) external returns (uint amountETH);
+
     function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
         address token,
         uint liquidity,
@@ -18,7 +19,10 @@ interface IUniswapV2Router02 is IUniswapV2Router01 {
         uint amountETHMin,
         address to,
         uint deadline,
-        bool approveMax, uint8 v, bytes32 r, bytes32 s
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
     ) external returns (uint amountETH);
 
     function swapExactTokensForTokensSupportingFeeOnTransferTokens(
@@ -28,12 +32,14 @@ interface IUniswapV2Router02 is IUniswapV2Router01 {
         address to,
         uint deadline
     ) external;
+
     function swapExactETHForTokensSupportingFeeOnTransferTokens(
         uint amountOutMin,
         address[] calldata path,
         address to,
         uint deadline
     ) external payable;
+
     function swapExactTokensForETHSupportingFeeOnTransferTokens(
         uint amountIn,
         uint amountOutMin,

--- a/contracts/AMM/UniswapV2/interfaces/IWETH.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IWETH.sol
@@ -1,0 +1,7 @@
+pragma solidity >=0.5.0;
+
+interface IWETH {
+    function deposit() external payable;
+    function transfer(address to, uint value) external returns (bool);
+    function withdraw(uint) external;
+}

--- a/contracts/AMM/UniswapV2/interfaces/IWETH.sol
+++ b/contracts/AMM/UniswapV2/interfaces/IWETH.sol
@@ -2,6 +2,8 @@ pragma solidity >=0.5.0;
 
 interface IWETH {
     function deposit() external payable;
+
     function transfer(address to, uint value) external returns (bool);
+
     function withdraw(uint) external;
 }

--- a/contracts/AMM/UniswapV2/libraries/Math.sol
+++ b/contracts/AMM/UniswapV2/libraries/Math.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.6.0;
+
+// a library for performing various math operations
+
+library Math {
+    function min(uint x, uint y) internal pure returns (uint z) {
+        z = x < y ? x : y;
+    }
+
+    // babylonian method (https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method)
+    function sqrt(uint y) internal pure returns (uint z) {
+        if (y > 3) {
+            z = y;
+            uint x = y / 2 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / x + x) / 2;
+            }
+        } else if (y != 0) {
+            z = 1;
+        }
+    }
+}

--- a/contracts/AMM/UniswapV2/libraries/SafeMath.sol
+++ b/contracts/AMM/UniswapV2/libraries/SafeMath.sol
@@ -1,0 +1,17 @@
+pragma solidity >=0.5.16;
+
+// a library for performing overflow-safe math, courtesy of DappHub (https://github.com/dapphub/ds-math)
+
+library SafeMath {
+    function add(uint x, uint y) internal pure returns (uint z) {
+        require((z = x + y) >= x, 'ds-math-add-overflow');
+    }
+
+    function sub(uint x, uint y) internal pure returns (uint z) {
+        require((z = x - y) <= x, 'ds-math-sub-underflow');
+    }
+
+    function mul(uint x, uint y) internal pure returns (uint z) {
+        require(y == 0 || (z = x * y) / y == x, 'ds-math-mul-overflow');
+    }
+}

--- a/contracts/AMM/UniswapV2/libraries/SafeMath.sol
+++ b/contracts/AMM/UniswapV2/libraries/SafeMath.sol
@@ -4,14 +4,14 @@ pragma solidity >=0.5.16;
 
 library SafeMath {
     function add(uint x, uint y) internal pure returns (uint z) {
-        require((z = x + y) >= x, 'ds-math-add-overflow');
+        require((z = x + y) >= x, "ds-math-add-overflow");
     }
 
     function sub(uint x, uint y) internal pure returns (uint z) {
-        require((z = x - y) <= x, 'ds-math-sub-underflow');
+        require((z = x - y) <= x, "ds-math-sub-underflow");
     }
 
     function mul(uint x, uint y) internal pure returns (uint z) {
-        require(y == 0 || (z = x * y) / y == x, 'ds-math-mul-overflow');
+        require(y == 0 || (z = x * y) / y == x, "ds-math-mul-overflow");
     }
 }

--- a/contracts/AMM/UniswapV2/libraries/TransferHelper.sol
+++ b/contracts/AMM/UniswapV2/libraries/TransferHelper.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity >=0.6.0;
+
+// helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false
+library TransferHelper {
+    function safeApprove(
+        address token,
+        address to,
+        uint256 value
+    ) internal {
+        // bytes4(keccak256(bytes('approve(address,uint256)')));
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x095ea7b3, to, value));
+        require(
+            success && (data.length == 0 || abi.decode(data, (bool))),
+            'TransferHelper::safeApprove: approve failed'
+        );
+    }
+
+    function safeTransfer(
+        address token,
+        address to,
+        uint256 value
+    ) internal {
+        // bytes4(keccak256(bytes('transfer(address,uint256)')));
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0xa9059cbb, to, value));
+        require(
+            success && (data.length == 0 || abi.decode(data, (bool))),
+            'TransferHelper::safeTransfer: transfer failed'
+        );
+    }
+
+    function safeTransferFrom(
+        address token,
+        address from,
+        address to,
+        uint256 value
+    ) internal {
+        // bytes4(keccak256(bytes('transferFrom(address,address,uint256)')));
+        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x23b872dd, from, to, value));
+        require(
+            success && (data.length == 0 || abi.decode(data, (bool))),
+            'TransferHelper::transferFrom: transferFrom failed'
+        );
+    }
+
+    function safeTransferETH(address to, uint256 value) internal {
+        (bool success, ) = to.call{value: value}(new bytes(0));
+        require(success, 'TransferHelper::safeTransferETH: ETH transfer failed');
+    }
+}

--- a/contracts/AMM/UniswapV2/libraries/TransferHelper.sol
+++ b/contracts/AMM/UniswapV2/libraries/TransferHelper.sol
@@ -4,29 +4,25 @@ pragma solidity >=0.6.0;
 
 // helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false
 library TransferHelper {
-    function safeApprove(
-        address token,
-        address to,
-        uint256 value
-    ) internal {
+    function safeApprove(address token, address to, uint256 value) internal {
         // bytes4(keccak256(bytes('approve(address,uint256)')));
-        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x095ea7b3, to, value));
+        (bool success, bytes memory data) = token.call(
+            abi.encodeWithSelector(0x095ea7b3, to, value)
+        );
         require(
             success && (data.length == 0 || abi.decode(data, (bool))),
-            'TransferHelper::safeApprove: approve failed'
+            "TransferHelper::safeApprove: approve failed"
         );
     }
 
-    function safeTransfer(
-        address token,
-        address to,
-        uint256 value
-    ) internal {
+    function safeTransfer(address token, address to, uint256 value) internal {
         // bytes4(keccak256(bytes('transfer(address,uint256)')));
-        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0xa9059cbb, to, value));
+        (bool success, bytes memory data) = token.call(
+            abi.encodeWithSelector(0xa9059cbb, to, value)
+        );
         require(
             success && (data.length == 0 || abi.decode(data, (bool))),
-            'TransferHelper::safeTransfer: transfer failed'
+            "TransferHelper::safeTransfer: transfer failed"
         );
     }
 
@@ -37,15 +33,20 @@ library TransferHelper {
         uint256 value
     ) internal {
         // bytes4(keccak256(bytes('transferFrom(address,address,uint256)')));
-        (bool success, bytes memory data) = token.call(abi.encodeWithSelector(0x23b872dd, from, to, value));
+        (bool success, bytes memory data) = token.call(
+            abi.encodeWithSelector(0x23b872dd, from, to, value)
+        );
         require(
             success && (data.length == 0 || abi.decode(data, (bool))),
-            'TransferHelper::transferFrom: transferFrom failed'
+            "TransferHelper::transferFrom: transferFrom failed"
         );
     }
 
     function safeTransferETH(address to, uint256 value) internal {
         (bool success, ) = to.call{value: value}(new bytes(0));
-        require(success, 'TransferHelper::safeTransferETH: ETH transfer failed');
+        require(
+            success,
+            "TransferHelper::safeTransferETH: ETH transfer failed"
+        );
     }
 }

--- a/contracts/AMM/UniswapV2/libraries/UQ112x112.sol
+++ b/contracts/AMM/UniswapV2/libraries/UQ112x112.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.6.0;
+
+// a library for handling binary fixed point numbers (https://en.wikipedia.org/wiki/Q_(number_format))
+
+// range: [0, 2**112 - 1]
+// resolution: 1 / 2**112
+
+library UQ112x112 {
+    uint224 constant Q112 = 2**112;
+
+    // encode a uint112 as a UQ112x112
+    function encode(uint112 y) internal pure returns (uint224 z) {
+        z = uint224(y) * Q112; // never overflows
+    }
+
+    // divide a UQ112x112 by a uint112, returning a UQ112x112
+    function uqdiv(uint224 x, uint112 y) internal pure returns (uint224 z) {
+        z = x / uint224(y);
+    }
+}

--- a/contracts/AMM/UniswapV2/libraries/UQ112x112.sol
+++ b/contracts/AMM/UniswapV2/libraries/UQ112x112.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.6.0;
 // resolution: 1 / 2**112
 
 library UQ112x112 {
-    uint224 constant Q112 = 2**112;
+    uint224 constant Q112 = 2 ** 112;
 
     // encode a uint112 as a UQ112x112
     function encode(uint112 y) internal pure returns (uint224 z) {

--- a/contracts/AMM/UniswapV2/libraries/UniswapV2Library.sol
+++ b/contracts/AMM/UniswapV2/libraries/UniswapV2Library.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.5.0;
 
-import '../interfaces/IUniswapV2Pair.sol';
+import "../interfaces/IUniswapV2Pair.sol";
 
 import "./SafeMath.sol";
 
@@ -8,42 +8,81 @@ library UniswapV2Library {
     using SafeMath for uint;
 
     // returns sorted token addresses, used to handle return values from pairs sorted in this order
-    function sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
-        require(tokenA != tokenB, 'UniswapV2Library: IDENTICAL_ADDRESSES');
-        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
-        require(token0 != address(0), 'UniswapV2Library: ZERO_ADDRESS');
+    function sortTokens(
+        address tokenA,
+        address tokenB
+    ) internal pure returns (address token0, address token1) {
+        require(tokenA != tokenB, "UniswapV2Library: IDENTICAL_ADDRESSES");
+        (token0, token1) = tokenA < tokenB
+            ? (tokenA, tokenB)
+            : (tokenB, tokenA);
+        require(token0 != address(0), "UniswapV2Library: ZERO_ADDRESS");
     }
 
     // calculates the CREATE2 address for a pair without making any external calls
-    function pairFor(address factory, address tokenA, address tokenB) internal pure returns (address pair) {
+    function pairFor(
+        address factory,
+        address tokenA,
+        address tokenB
+    ) internal pure returns (address pair) {
         (address token0, address token1) = sortTokens(tokenA, tokenB);
-        pair = address(uint160(uint(keccak256(abi.encodePacked(
-                hex'ff',
-                factory,
-                keccak256(abi.encodePacked(token0, token1)),
-                hex'40ccc7d6659c66489c67f86ee7da56ef3d635186e37713baa8676c9dee5f9325' 
-                //hex'96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' // init code hash
-            )))));
+        pair = address(
+            uint160(
+                uint(
+                    keccak256(
+                        abi.encodePacked(
+                            hex"ff",
+                            factory,
+                            keccak256(abi.encodePacked(token0, token1)),
+                            hex"40ccc7d6659c66489c67f86ee7da56ef3d635186e37713baa8676c9dee5f9325"
+                            //hex'96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' // init code hash
+                        )
+                    )
+                )
+            )
+        );
     }
 
     // fetches and sorts the reserves for a pair
-    function getReserves(address factory, address tokenA, address tokenB) internal view returns (uint reserveA, uint reserveB) {
-        (address token0,) = sortTokens(tokenA, tokenB);
-        (uint reserve0, uint reserve1,) = IUniswapV2Pair(pairFor(factory, tokenA, tokenB)).getReserves();
-        (reserveA, reserveB) = tokenA == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+    function getReserves(
+        address factory,
+        address tokenA,
+        address tokenB
+    ) internal view returns (uint reserveA, uint reserveB) {
+        (address token0, ) = sortTokens(tokenA, tokenB);
+        (uint reserve0, uint reserve1, ) = IUniswapV2Pair(
+            pairFor(factory, tokenA, tokenB)
+        ).getReserves();
+        (reserveA, reserveB) = tokenA == token0
+            ? (reserve0, reserve1)
+            : (reserve1, reserve0);
     }
 
     // given some amount of an asset and pair reserves, returns an equivalent amount of the other asset
-    function quote(uint amountA, uint reserveA, uint reserveB) internal pure returns (uint amountB) {
-        require(amountA > 0, 'UniswapV2Library: INSUFFICIENT_AMOUNT');
-        require(reserveA > 0 && reserveB > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+    function quote(
+        uint amountA,
+        uint reserveA,
+        uint reserveB
+    ) internal pure returns (uint amountB) {
+        require(amountA > 0, "UniswapV2Library: INSUFFICIENT_AMOUNT");
+        require(
+            reserveA > 0 && reserveB > 0,
+            "UniswapV2Library: INSUFFICIENT_LIQUIDITY"
+        );
         amountB = amountA.mul(reserveB) / reserveA;
     }
 
     // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
-    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) internal pure returns (uint amountOut) {
-        require(amountIn > 0, 'UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT');
-        require(reserveIn > 0 && reserveOut > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+    function getAmountOut(
+        uint amountIn,
+        uint reserveIn,
+        uint reserveOut
+    ) internal pure returns (uint amountOut) {
+        require(amountIn > 0, "UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT");
+        require(
+            reserveIn > 0 && reserveOut > 0,
+            "UniswapV2Library: INSUFFICIENT_LIQUIDITY"
+        );
         uint amountInWithFee = amountIn.mul(997);
         uint numerator = amountInWithFee.mul(reserveOut);
         uint denominator = reserveIn.mul(1000).add(amountInWithFee);
@@ -51,32 +90,55 @@ library UniswapV2Library {
     }
 
     // given an output amount of an asset and pair reserves, returns a required input amount of the other asset
-    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) internal pure returns (uint amountIn) {
-        require(amountOut > 0, 'UniswapV2Library: INSUFFICIENT_OUTPUT_AMOUNT');
-        require(reserveIn > 0 && reserveOut > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+    function getAmountIn(
+        uint amountOut,
+        uint reserveIn,
+        uint reserveOut
+    ) internal pure returns (uint amountIn) {
+        require(amountOut > 0, "UniswapV2Library: INSUFFICIENT_OUTPUT_AMOUNT");
+        require(
+            reserveIn > 0 && reserveOut > 0,
+            "UniswapV2Library: INSUFFICIENT_LIQUIDITY"
+        );
         uint numerator = reserveIn.mul(amountOut).mul(1000);
         uint denominator = reserveOut.sub(amountOut).mul(997);
         amountIn = (numerator / denominator).add(1);
     }
 
     // performs chained getAmountOut calculations on any number of pairs
-    function getAmountsOut(address factory, uint amountIn, address[] memory path) internal view returns (uint[] memory amounts) {
-        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
+    function getAmountsOut(
+        address factory,
+        uint amountIn,
+        address[] memory path
+    ) internal view returns (uint[] memory amounts) {
+        require(path.length >= 2, "UniswapV2Library: INVALID_PATH");
         amounts = new uint[](path.length);
         amounts[0] = amountIn;
         for (uint i; i < path.length - 1; i++) {
-            (uint reserveIn, uint reserveOut) = getReserves(factory, path[i], path[i + 1]);
+            (uint reserveIn, uint reserveOut) = getReserves(
+                factory,
+                path[i],
+                path[i + 1]
+            );
             amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
         }
     }
 
     // performs chained getAmountIn calculations on any number of pairs
-    function getAmountsIn(address factory, uint amountOut, address[] memory path) internal view returns (uint[] memory amounts) {
-        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
+    function getAmountsIn(
+        address factory,
+        uint amountOut,
+        address[] memory path
+    ) internal view returns (uint[] memory amounts) {
+        require(path.length >= 2, "UniswapV2Library: INVALID_PATH");
         amounts = new uint[](path.length);
         amounts[amounts.length - 1] = amountOut;
         for (uint i = path.length - 1; i > 0; i--) {
-            (uint reserveIn, uint reserveOut) = getReserves(factory, path[i - 1], path[i]);
+            (uint reserveIn, uint reserveOut) = getReserves(
+                factory,
+                path[i - 1],
+                path[i]
+            );
             amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
         }
     }

--- a/contracts/AMM/UniswapV2/libraries/UniswapV2Library.sol
+++ b/contracts/AMM/UniswapV2/libraries/UniswapV2Library.sol
@@ -1,0 +1,83 @@
+pragma solidity >=0.5.0;
+
+import '../interfaces/IUniswapV2Pair.sol';
+
+import "./SafeMath.sol";
+
+library UniswapV2Library {
+    using SafeMath for uint;
+
+    // returns sorted token addresses, used to handle return values from pairs sorted in this order
+    function sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
+        require(tokenA != tokenB, 'UniswapV2Library: IDENTICAL_ADDRESSES');
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        require(token0 != address(0), 'UniswapV2Library: ZERO_ADDRESS');
+    }
+
+    // calculates the CREATE2 address for a pair without making any external calls
+    function pairFor(address factory, address tokenA, address tokenB) internal pure returns (address pair) {
+        (address token0, address token1) = sortTokens(tokenA, tokenB);
+        pair = address(uint160(uint(keccak256(abi.encodePacked(
+                hex'ff',
+                factory,
+                keccak256(abi.encodePacked(token0, token1)),
+                hex'40ccc7d6659c66489c67f86ee7da56ef3d635186e37713baa8676c9dee5f9325' 
+                //hex'96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' // init code hash
+            )))));
+    }
+
+    // fetches and sorts the reserves for a pair
+    function getReserves(address factory, address tokenA, address tokenB) internal view returns (uint reserveA, uint reserveB) {
+        (address token0,) = sortTokens(tokenA, tokenB);
+        (uint reserve0, uint reserve1,) = IUniswapV2Pair(pairFor(factory, tokenA, tokenB)).getReserves();
+        (reserveA, reserveB) = tokenA == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+    }
+
+    // given some amount of an asset and pair reserves, returns an equivalent amount of the other asset
+    function quote(uint amountA, uint reserveA, uint reserveB) internal pure returns (uint amountB) {
+        require(amountA > 0, 'UniswapV2Library: INSUFFICIENT_AMOUNT');
+        require(reserveA > 0 && reserveB > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+        amountB = amountA.mul(reserveB) / reserveA;
+    }
+
+    // given an input amount of an asset and pair reserves, returns the maximum output amount of the other asset
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) internal pure returns (uint amountOut) {
+        require(amountIn > 0, 'UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT');
+        require(reserveIn > 0 && reserveOut > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+        uint amountInWithFee = amountIn.mul(997);
+        uint numerator = amountInWithFee.mul(reserveOut);
+        uint denominator = reserveIn.mul(1000).add(amountInWithFee);
+        amountOut = numerator / denominator;
+    }
+
+    // given an output amount of an asset and pair reserves, returns a required input amount of the other asset
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) internal pure returns (uint amountIn) {
+        require(amountOut > 0, 'UniswapV2Library: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(reserveIn > 0 && reserveOut > 0, 'UniswapV2Library: INSUFFICIENT_LIQUIDITY');
+        uint numerator = reserveIn.mul(amountOut).mul(1000);
+        uint denominator = reserveOut.sub(amountOut).mul(997);
+        amountIn = (numerator / denominator).add(1);
+    }
+
+    // performs chained getAmountOut calculations on any number of pairs
+    function getAmountsOut(address factory, uint amountIn, address[] memory path) internal view returns (uint[] memory amounts) {
+        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
+        amounts = new uint[](path.length);
+        amounts[0] = amountIn;
+        for (uint i; i < path.length - 1; i++) {
+            (uint reserveIn, uint reserveOut) = getReserves(factory, path[i], path[i + 1]);
+            amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
+        }
+    }
+
+    // performs chained getAmountIn calculations on any number of pairs
+    function getAmountsIn(address factory, uint amountOut, address[] memory path) internal view returns (uint[] memory amounts) {
+        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
+        amounts = new uint[](path.length);
+        amounts[amounts.length - 1] = amountOut;
+        for (uint i = path.length - 1; i > 0; i--) {
+            (uint reserveIn, uint reserveOut) = getReserves(factory, path[i - 1], path[i]);
+            amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
+        }
+    }
+}

--- a/contracts/AMM/UniswapV2/libraries/WETH.sol
+++ b/contracts/AMM/UniswapV2/libraries/WETH.sol
@@ -1,6 +1,6 @@
 /**
  *Submitted for verification at Etherscan.io on 2017-12-12
-*/
+ */
 
 // Copyright (C) 2015, 2016, 2017 Dapphub
 
@@ -17,28 +17,30 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity  ^0.6.6;
+pragma solidity ^0.6.6;
 
 contract WETH9 {
-    string public name     = "Wrapped Ether";
-    string public symbol   = "WETH";
-    uint8  public decimals = 18;
+    string public name = "Wrapped Ether";
+    string public symbol = "WETH";
+    uint8 public decimals = 18;
 
-    event  Approval(address indexed src, address indexed guy, uint wad);
-    event  Transfer(address indexed src, address indexed dst, uint wad);
-    event  Deposit(address indexed dst, uint wad);
-    event  Withdrawal(address indexed src, uint wad);
+    event Approval(address indexed src, address indexed guy, uint wad);
+    event Transfer(address indexed src, address indexed dst, uint wad);
+    event Deposit(address indexed dst, uint wad);
+    event Withdrawal(address indexed src, uint wad);
 
-    mapping (address => uint)                       public  balanceOf;
-    mapping (address => mapping (address => uint))  public  allowance;
+    mapping(address => uint) public balanceOf;
+    mapping(address => mapping(address => uint)) public allowance;
 
     fallback() external payable {
         deposit();
     }
+
     function deposit() public payable {
         balanceOf[msg.sender] += msg.value;
         emit Deposit(msg.sender, msg.value);
     }
+
     function withdraw(uint wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
@@ -60,10 +62,11 @@ contract WETH9 {
         return transferFrom(msg.sender, dst, wad);
     }
 
-    function transferFrom(address src, address dst, uint wad)
-        public
-        returns (bool)
-    {
+    function transferFrom(
+        address src,
+        address dst,
+        uint wad
+    ) public returns (bool) {
         require(balanceOf[src] >= wad);
 
         if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
@@ -79,7 +82,6 @@ contract WETH9 {
         return true;
     }
 }
-
 
 /*
                     GNU GENERAL PUBLIC LICENSE

--- a/contracts/AMM/UniswapV2/libraries/WETH.sol
+++ b/contracts/AMM/UniswapV2/libraries/WETH.sol
@@ -1,0 +1,760 @@
+/**
+ *Submitted for verification at Etherscan.io on 2017-12-12
+*/
+
+// Copyright (C) 2015, 2016, 2017 Dapphub
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity  ^0.6.6;
+
+contract WETH9 {
+    string public name     = "Wrapped Ether";
+    string public symbol   = "WETH";
+    uint8  public decimals = 18;
+
+    event  Approval(address indexed src, address indexed guy, uint wad);
+    event  Transfer(address indexed src, address indexed dst, uint wad);
+    event  Deposit(address indexed dst, uint wad);
+    event  Withdrawal(address indexed src, uint wad);
+
+    mapping (address => uint)                       public  balanceOf;
+    mapping (address => mapping (address => uint))  public  allowance;
+
+    fallback() external payable {
+        deposit();
+    }
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+        emit Deposit(msg.sender, msg.value);
+    }
+    function withdraw(uint wad) public {
+        require(balanceOf[msg.sender] >= wad);
+        balanceOf[msg.sender] -= wad;
+        msg.sender.transfer(wad);
+        emit Withdrawal(msg.sender, wad);
+    }
+
+    function totalSupply() public view returns (uint) {
+        return address(this).balance;
+    }
+
+    function approve(address guy, uint wad) public returns (bool) {
+        allowance[msg.sender][guy] = wad;
+        emit Approval(msg.sender, guy, wad);
+        return true;
+    }
+
+    function transfer(address dst, uint wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(address src, address dst, uint wad)
+        public
+        returns (bool)
+    {
+        require(balanceOf[src] >= wad);
+
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad);
+            allowance[src][msg.sender] -= wad;
+        }
+
+        balanceOf[src] -= wad;
+        balanceOf[dst] += wad;
+
+        emit Transfer(src, dst, wad);
+
+        return true;
+    }
+}
+
+
+/*
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+
+*/

--- a/contracts/AMM/UniswapV2/uni-v2/UniswapV2ERC20.sol
+++ b/contracts/AMM/UniswapV2/uni-v2/UniswapV2ERC20.sol
@@ -1,0 +1,127 @@
+pragma solidity ^0.6.0;
+
+import "../interfaces/IUniswapV2ERC20.sol";
+import "../libraries/SafeMath.sol";
+
+contract UniswapV2ERC20 {
+    using SafeMath for uint;
+
+    string public constant name = "Uniswap V2";
+    string public constant symbol = "UNI-V2";
+    uint8 public constant decimals = 18;
+    uint public totalSupply;
+    mapping(address => uint) public balanceOf;
+    mapping(address => mapping(address => uint)) public allowance;
+
+    bytes32 public DOMAIN_SEPARATOR;
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant PERMIT_TYPEHASH =
+        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+    mapping(address => uint) public nonces;
+
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+    constructor() public {
+        uint chainId;
+        assembly {
+            chainId := chainid()
+        }
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes(name)),
+                keccak256(bytes("1")),
+                chainId,
+                address(this)
+            )
+        );
+    }
+
+    function _mint(address to, uint value) internal {
+        totalSupply = totalSupply.add(value);
+        balanceOf[to] = balanceOf[to].add(value);
+        emit Transfer(address(0), to, value);
+    }
+
+    function _burn(address from, uint value) internal {
+        balanceOf[from] = balanceOf[from].sub(value);
+        totalSupply = totalSupply.sub(value);
+        emit Transfer(from, address(0), value);
+    }
+
+    function _approve(address owner, address spender, uint value) private {
+        allowance[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function _transfer(address from, address to, uint value) private {
+        balanceOf[from] = balanceOf[from].sub(value);
+        balanceOf[to] = balanceOf[to].add(value);
+        emit Transfer(from, to, value);
+    }
+
+    function approve(address spender, uint value) external returns (bool) {
+        _approve(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint value) external virtual returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint value
+    ) external returns (bool) {
+        if (allowance[from][msg.sender] != uint(-1)) {
+            allowance[from][msg.sender] = allowance[from][msg.sender].sub(
+                value
+            );
+        }
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function permit(
+        address owner,
+        address spender,
+        uint value,
+        uint deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(deadline >= block.timestamp, "UniswapV2: EXPIRED");
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(
+                    abi.encode(
+                        PERMIT_TYPEHASH,
+                        owner,
+                        spender,
+                        value,
+                        nonces[owner]++,
+                        deadline
+                    )
+                )
+            )
+        );
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        require(
+            recoveredAddress != address(0) && recoveredAddress == owner,
+            "UniswapV2: INVALID_SIGNATURE"
+        );
+        _approve(owner, spender, value);
+    }
+
+    function mint(address account, uint amount) external {
+        _mint(account, amount);
+    }
+}

--- a/contracts/AMM/UniswapV2/uni-v2/UniswapV2Factory.sol
+++ b/contracts/AMM/UniswapV2/uni-v2/UniswapV2Factory.sol
@@ -1,0 +1,62 @@
+pragma solidity ^0.6.0;
+
+import "../interfaces/IUniswapV2Factory.sol";
+import "./UniswapV2Pair.sol";
+
+contract UniswapV2Factory is IUniswapV2Factory {
+    address public override feeTo;
+    address public override feeToSetter;
+
+    mapping(address => mapping(address => address)) public override getPair;
+    address[] public override allPairs;
+
+    event PairCreated(
+        address indexed token0,
+        address indexed token1,
+        address pair,
+        uint
+    );
+
+    constructor(address _feeToSetter) public {
+        feeToSetter = _feeToSetter;
+    }
+
+    function allPairsLength() external view override returns (uint) {
+        return allPairs.length;
+    }
+
+    function createPair(
+        address tokenA,
+        address tokenB
+    ) external override returns (address pair) {
+        require(tokenA != tokenB, "UniswapV2: IDENTICAL_ADDRESSES");
+        (address token0, address token1) = tokenA < tokenB
+            ? (tokenA, tokenB)
+            : (tokenB, tokenA);
+        require(token0 != address(0), "UniswapV2: ZERO_ADDRESS");
+        require(
+            getPair[token0][token1] == address(0),
+            "UniswapV2: PAIR_EXISTS"
+        ); // single check is sufficient
+        bytes memory bytecode = type(UniswapV2Pair).creationCode;
+        bytes32 salt = keccak256(abi.encodePacked(token0, token1));
+        assembly {
+            pair := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+        IUniswapV2Pair(pair).initialize(token0, token1);
+        getPair[token0][token1] = pair;
+        getPair[token1][token0] = pair; // populate mapping in the reverse direction
+        allPairs.push(pair);
+        emit PairCreated(token0, token1, pair, allPairs.length);
+    }
+
+    function setFeeTo(address _feeTo) external override {
+        require(msg.sender == feeToSetter, "UniswapV2: FORBIDDEN");
+        feeTo = _feeTo;
+    }
+
+    function setFeeToSetter(address _feeToSetter) external override {
+        require(msg.sender == feeToSetter, "UniswapV2: FORBIDDEN");
+        feeToSetter = _feeToSetter;
+    }
+}

--- a/contracts/AMM/UniswapV2/uni-v2/UniswapV2Pair.sol
+++ b/contracts/AMM/UniswapV2/uni-v2/UniswapV2Pair.sol
@@ -1,0 +1,288 @@
+pragma solidity ^0.6.0;
+
+import "../interfaces/IUniswapV2Pair.sol";
+import "./UniswapV2ERC20.sol";
+import "../libraries/Math.sol";
+import "../libraries/UQ112x112.sol";
+import "../interfaces/IERC20.sol";
+import "../interfaces/IUniswapV2Factory.sol";
+import "../interfaces/IUniswapV2Callee.sol";
+
+contract UniswapV2Pair is UniswapV2ERC20 {
+    using SafeMath for uint;
+    using UQ112x112 for uint224;
+
+    uint public constant MINIMUM_LIQUIDITY = 10 ** 3;
+    bytes4 private constant SELECTOR =
+        bytes4(keccak256(bytes("transfer(address,uint256)")));
+
+    address public factory;
+    address public token0;
+    address public token1;
+
+    uint112 private reserve0; // uses single storage slot, accessible via getReserves
+    uint112 private reserve1; // uses single storage slot, accessible via getReserves
+    uint32 private blockTimestampLast; // uses single storage slot, accessible via getReserves
+
+    uint public price0CumulativeLast;
+    uint public price1CumulativeLast;
+    uint public kLast; // reserve0 * reserve1, as of immediately after the most recent liquidity event
+
+    uint private unlocked = 1;
+    modifier lock() {
+        require(unlocked == 1, "UniswapV2: LOCKED");
+        unlocked = 0;
+        _;
+        unlocked = 1;
+    }
+
+    function getReserves()
+        public
+        view
+        returns (
+            uint112 _reserve0,
+            uint112 _reserve1,
+            uint32 _blockTimestampLast
+        )
+    {
+        _reserve0 = reserve0;
+        _reserve1 = reserve1;
+        _blockTimestampLast = blockTimestampLast;
+    }
+
+    function _safeTransfer(address token, address to, uint value) private {
+        (bool success, bytes memory data) = token.call(
+            abi.encodeWithSelector(SELECTOR, to, value)
+        );
+        require(
+            success && (data.length == 0 || abi.decode(data, (bool))),
+            "UniswapV2: TRANSFER_FAILED"
+        );
+    }
+
+    event Mint(address indexed sender, uint amount0, uint amount1);
+    event Burn(
+        address indexed sender,
+        uint amount0,
+        uint amount1,
+        address indexed to
+    );
+    event Swap(
+        address indexed sender,
+        uint amount0In,
+        uint amount1In,
+        uint amount0Out,
+        uint amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    constructor() public {
+        factory = msg.sender;
+    }
+
+    // called once by the factory at time of deployment
+    function initialize(address _token0, address _token1) external {
+        require(msg.sender == factory, "UniswapV2: FORBIDDEN"); // sufficient check
+        token0 = _token0;
+        token1 = _token1;
+    }
+
+    // update reserves and, on the first call per block, price accumulators
+    function _update(
+        uint balance0,
+        uint balance1,
+        uint112 _reserve0,
+        uint112 _reserve1
+    ) private {
+        require(
+            balance0 <= uint112(-1) && balance1 <= uint112(-1),
+            "UniswapV2: OVERFLOW"
+        );
+        uint32 blockTimestamp = uint32(block.timestamp % 2 ** 32);
+        uint32 timeElapsed = blockTimestamp - blockTimestampLast; // overflow is desired
+        if (timeElapsed > 0 && _reserve0 != 0 && _reserve1 != 0) {
+            // * never overflows, and + overflow is desired
+            price0CumulativeLast +=
+                uint(UQ112x112.encode(_reserve1).uqdiv(_reserve0)) *
+                timeElapsed;
+            price1CumulativeLast +=
+                uint(UQ112x112.encode(_reserve0).uqdiv(_reserve1)) *
+                timeElapsed;
+        }
+        reserve0 = uint112(balance0);
+        reserve1 = uint112(balance1);
+        blockTimestampLast = blockTimestamp;
+        emit Sync(reserve0, reserve1);
+    }
+
+    // if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
+    function _mintFee(
+        uint112 _reserve0,
+        uint112 _reserve1
+    ) private returns (bool feeOn) {
+        address feeTo = IUniswapV2Factory(factory).feeTo();
+        feeOn = feeTo != address(0);
+        uint _kLast = kLast; // gas savings
+        if (feeOn) {
+            if (_kLast != 0) {
+                uint rootK = Math.sqrt(uint(_reserve0).mul(_reserve1));
+                uint rootKLast = Math.sqrt(_kLast);
+                if (rootK > rootKLast) {
+                    uint numerator = totalSupply.mul(rootK.sub(rootKLast));
+                    uint denominator = rootK.mul(5).add(rootKLast);
+                    uint liquidity = numerator / denominator;
+                    if (liquidity > 0) _mint(feeTo, liquidity);
+                }
+            }
+        } else if (_kLast != 0) {
+            kLast = 0;
+        }
+    }
+
+    // this low-level function should be called from a contract which performs important safety checks
+    function mint(address to) external lock returns (uint liquidity) {
+        (uint112 _reserve0, uint112 _reserve1, ) = getReserves(); // gas savings
+        uint balance0 = IERC20(token0).balanceOf(address(this));
+        uint balance1 = IERC20(token1).balanceOf(address(this));
+
+        uint amount0 = balance0.sub(_reserve0);
+        uint amount1 = balance1.sub(_reserve1);
+
+        bool feeOn = _mintFee(_reserve0, _reserve1);
+        uint _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
+        if (_totalSupply == 0) {
+            liquidity = Math.sqrt(amount0.mul(amount1)).sub(MINIMUM_LIQUIDITY);
+            _mint(address(0), MINIMUM_LIQUIDITY); // permanently lock the first MINIMUM_LIQUIDITY tokens
+        } else {
+            liquidity = Math.min(
+                amount0.mul(_totalSupply) / _reserve0,
+                amount1.mul(_totalSupply) / _reserve1
+            );
+        }
+
+        require(liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED");
+        _mint(to, liquidity);
+
+        _update(balance0, balance1, _reserve0, _reserve1);
+        if (feeOn) kLast = uint(reserve0).mul(reserve1); // reserve0 and reserve1 are up-to-date
+        emit Mint(msg.sender, amount0, amount1);
+    }
+
+    // this low-level function should be called from a contract which performs important safety checks
+    function burn(
+        address to
+    ) external lock returns (uint amount0, uint amount1) {
+        (uint112 _reserve0, uint112 _reserve1, ) = getReserves(); // gas savings
+        address _token0 = token0; // gas savings
+        address _token1 = token1; // gas savings
+        uint balance0 = IERC20(_token0).balanceOf(address(this));
+        uint balance1 = IERC20(_token1).balanceOf(address(this));
+        uint liquidity = balanceOf[address(this)];
+
+        bool feeOn = _mintFee(_reserve0, _reserve1);
+        uint _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
+        amount0 = liquidity.mul(balance0) / _totalSupply; // using balances ensures pro-rata distribution
+        amount1 = liquidity.mul(balance1) / _totalSupply; // using balances ensures pro-rata distribution
+        require(
+            amount0 > 0 && amount1 > 0,
+            "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+        );
+        _burn(address(this), liquidity);
+        _safeTransfer(_token0, to, amount0);
+        _safeTransfer(_token1, to, amount1);
+        balance0 = IERC20(_token0).balanceOf(address(this));
+        balance1 = IERC20(_token1).balanceOf(address(this));
+
+        _update(balance0, balance1, _reserve0, _reserve1);
+        if (feeOn) kLast = uint(reserve0).mul(reserve1); // reserve0 and reserve1 are up-to-date
+        emit Burn(msg.sender, amount0, amount1, to);
+    }
+
+    // this low-level function should be called from a contract which performs important safety checks
+    function swap(
+        uint amount0Out,
+        uint amount1Out,
+        address to,
+        bytes calldata data
+    ) external lock {
+        require(
+            amount0Out > 0 || amount1Out > 0,
+            "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
+        (uint112 _reserve0, uint112 _reserve1, ) = getReserves(); // gas savings
+        require(
+            amount0Out < _reserve0 && amount1Out < _reserve1,
+            "UniswapV2: INSUFFICIENT_LIQUIDITY"
+        );
+
+        uint balance0;
+        uint balance1;
+        {
+            // scope for _token{0,1}, avoids stack too deep errors
+            address _token0 = token0;
+            address _token1 = token1;
+            require(to != _token0 && to != _token1, "UniswapV2: INVALID_TO");
+            if (amount0Out > 0) _safeTransfer(_token0, to, amount0Out); // optimistically transfer tokens
+            if (amount1Out > 0) _safeTransfer(_token1, to, amount1Out); // optimistically transfer tokens
+            if (data.length > 0)
+                IUniswapV2Callee(to).uniswapV2Call(
+                    msg.sender,
+                    amount0Out,
+                    amount1Out,
+                    data
+                );
+            balance0 = IERC20(_token0).balanceOf(address(this));
+            balance1 = IERC20(_token1).balanceOf(address(this));
+        }
+        uint amount0In = balance0 > _reserve0 - amount0Out
+            ? balance0 - (_reserve0 - amount0Out)
+            : 0;
+        uint amount1In = balance1 > _reserve1 - amount1Out
+            ? balance1 - (_reserve1 - amount1Out)
+            : 0;
+        require(
+            amount0In > 0 || amount1In > 0,
+            "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+        );
+        {
+            // scope for reserve{0,1}Adjusted, avoids stack too deep errors
+            uint balance0Adjusted = balance0.mul(1000).sub(amount0In.mul(3));
+            uint balance1Adjusted = balance1.mul(1000).sub(amount1In.mul(3));
+            require(
+                balance0Adjusted.mul(balance1Adjusted) >=
+                    uint(_reserve0).mul(_reserve1).mul(1000 ** 2),
+                "UniswapV2: K"
+            );
+        }
+
+        _update(balance0, balance1, _reserve0, _reserve1);
+        emit Swap(msg.sender, amount0In, amount1In, amount0Out, amount1Out, to);
+    }
+
+    // force balances to match reserves
+    function skim(address to) external lock {
+        address _token0 = token0; // gas savings
+        address _token1 = token1; // gas savings
+        _safeTransfer(
+            _token0,
+            to,
+            IERC20(_token0).balanceOf(address(this)).sub(reserve0)
+        );
+        _safeTransfer(
+            _token1,
+            to,
+            IERC20(_token1).balanceOf(address(this)).sub(reserve1)
+        );
+    }
+
+    // force reserves to match balances
+    function sync() external lock {
+        _update(
+            IERC20(token0).balanceOf(address(this)),
+            IERC20(token1).balanceOf(address(this)),
+            reserve0,
+            reserve1
+        );
+    }
+}

--- a/contracts/AMM/UniswapV2/uni-v2/UniswapV2Router01.sol
+++ b/contracts/AMM/UniswapV2/uni-v2/UniswapV2Router01.sol
@@ -1,0 +1,466 @@
+pragma solidity =0.6.6;
+
+import "../interfaces/IUniswapV2Factory.sol";
+import "../libraries/TransferHelper.sol";
+
+import "../libraries/UniswapV2Library.sol";
+import "../interfaces/IUniswapV2Router01.sol";
+import "../interfaces/IERC20.sol";
+import "../interfaces/IWETH.sol";
+
+contract UniswapV2Router01 is IUniswapV2Router01 {
+    address public immutable override factory;
+    address public immutable override WETH;
+
+    modifier ensure(uint deadline) {
+        require(deadline >= block.timestamp, "UniswapV2Router: EXPIRED");
+        _;
+    }
+
+    constructor(address _factory, address _WETH) public {
+        factory = _factory;
+        WETH = _WETH;
+    }
+
+    receive() external payable {
+        assert(msg.sender == WETH); // only accept ETH via fallback from the WETH contract
+    }
+
+    // **** ADD LIQUIDITY ****
+    function _addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin
+    ) private returns (uint amountA, uint amountB) {
+        // create the pair if it doesn't exist yet
+        if (IUniswapV2Factory(factory).getPair(tokenA, tokenB) == address(0)) {
+            IUniswapV2Factory(factory).createPair(tokenA, tokenB);
+        }
+        (uint reserveA, uint reserveB) = UniswapV2Library.getReserves(
+            factory,
+            tokenA,
+            tokenB
+        );
+        if (reserveA == 0 && reserveB == 0) {
+            (amountA, amountB) = (amountADesired, amountBDesired);
+        } else {
+            uint amountBOptimal = UniswapV2Library.quote(
+                amountADesired,
+                reserveA,
+                reserveB
+            );
+            if (amountBOptimal <= amountBDesired) {
+                require(
+                    amountBOptimal >= amountBMin,
+                    "UniswapV2Router: INSUFFICIENT_B_AMOUNT"
+                );
+                (amountA, amountB) = (amountADesired, amountBOptimal);
+            } else {
+                uint amountAOptimal = UniswapV2Library.quote(
+                    amountBDesired,
+                    reserveB,
+                    reserveA
+                );
+                assert(amountAOptimal <= amountADesired);
+                require(
+                    amountAOptimal >= amountAMin,
+                    "UniswapV2Router: INSUFFICIENT_A_AMOUNT"
+                );
+                (amountA, amountB) = (amountAOptimal, amountBDesired);
+            }
+        }
+    }
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    )
+        external
+        override
+        ensure(deadline)
+        returns (uint amountA, uint amountB, uint liquidity)
+    {
+        (amountA, amountB) = _addLiquidity(
+            tokenA,
+            tokenB,
+            amountADesired,
+            amountBDesired,
+            amountAMin,
+            amountBMin
+        );
+        address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
+        TransferHelper.safeTransferFrom(tokenA, msg.sender, pair, amountA);
+        TransferHelper.safeTransferFrom(tokenB, msg.sender, pair, amountB);
+        liquidity = IUniswapV2Pair(pair).mint(to);
+    }
+
+    function addLiquidityETH(
+        address token,
+        uint amountTokenDesired,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    )
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint amountToken, uint amountETH, uint liquidity)
+    {
+        (amountToken, amountETH) = _addLiquidity(
+            token,
+            WETH,
+            amountTokenDesired,
+            msg.value,
+            amountTokenMin,
+            amountETHMin
+        );
+        address pair = UniswapV2Library.pairFor(factory, token, WETH);
+        TransferHelper.safeTransferFrom(token, msg.sender, pair, amountToken);
+        IWETH(WETH).deposit{value: amountETH}();
+        assert(IWETH(WETH).transfer(pair, amountETH));
+        liquidity = IUniswapV2Pair(pair).mint(to);
+        if (msg.value > amountETH)
+            TransferHelper.safeTransferETH(msg.sender, msg.value - amountETH); // refund dust eth, if any
+    }
+
+    // **** REMOVE LIQUIDITY ****
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) public override ensure(deadline) returns (uint amountA, uint amountB) {
+        address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
+        IUniswapV2Pair(pair).transferFrom(msg.sender, pair, liquidity); // send liquidity to pair
+        (uint amount0, uint amount1) = IUniswapV2Pair(pair).burn(to);
+        (address token0, ) = UniswapV2Library.sortTokens(tokenA, tokenB);
+        (amountA, amountB) = tokenA == token0
+            ? (amount0, amount1)
+            : (amount1, amount0);
+        require(
+            amountA >= amountAMin,
+            "UniswapV2Router: INSUFFICIENT_A_AMOUNT"
+        );
+        require(
+            amountB >= amountBMin,
+            "UniswapV2Router: INSUFFICIENT_B_AMOUNT"
+        );
+    }
+
+    function removeLiquidityETH(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    )
+        public
+        override
+        ensure(deadline)
+        returns (uint amountToken, uint amountETH)
+    {
+        (amountToken, amountETH) = removeLiquidity(
+            token,
+            WETH,
+            liquidity,
+            amountTokenMin,
+            amountETHMin,
+            address(this),
+            deadline
+        );
+        TransferHelper.safeTransfer(token, to, amountToken);
+        IWETH(WETH).withdraw(amountETH);
+        TransferHelper.safeTransferETH(to, amountETH);
+    }
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override returns (uint amountA, uint amountB) {
+        address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
+        uint value = approveMax ? uint(-1) : liquidity;
+        IUniswapV2Pair(pair).permit(
+            msg.sender,
+            address(this),
+            value,
+            deadline,
+            v,
+            r,
+            s
+        );
+        (amountA, amountB) = removeLiquidity(
+            tokenA,
+            tokenB,
+            liquidity,
+            amountAMin,
+            amountBMin,
+            to,
+            deadline
+        );
+    }
+
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override returns (uint amountToken, uint amountETH) {
+        address pair = UniswapV2Library.pairFor(factory, token, WETH);
+        uint value = approveMax ? uint(-1) : liquidity;
+        IUniswapV2Pair(pair).permit(
+            msg.sender,
+            address(this),
+            value,
+            deadline,
+            v,
+            r,
+            s
+        );
+        (amountToken, amountETH) = removeLiquidityETH(
+            token,
+            liquidity,
+            amountTokenMin,
+            amountETHMin,
+            to,
+            deadline
+        );
+    }
+
+    // **** SWAP ****
+    // requires the initial amount to have already been sent to the first pair
+    function _swap(
+        uint[] memory amounts,
+        address[] memory path,
+        address _to
+    ) private {
+        for (uint i; i < path.length - 1; i++) {
+            (address input, address output) = (path[i], path[i + 1]);
+            (address token0, ) = UniswapV2Library.sortTokens(input, output);
+            uint amountOut = amounts[i + 1];
+            (uint amount0Out, uint amount1Out) = input == token0
+                ? (uint(0), amountOut)
+                : (amountOut, uint(0));
+            address to = i < path.length - 2
+                ? UniswapV2Library.pairFor(factory, output, path[i + 2])
+                : _to;
+            IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output))
+                .swap(amount0Out, amount1Out, to, new bytes(0));
+        }
+    }
+
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external override ensure(deadline) returns (uint[] memory amounts) {
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
+        require(
+            amounts[amounts.length - 1] >= amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
+        TransferHelper.safeTransferFrom(
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amounts[0]
+        );
+        _swap(amounts, path, to);
+    }
+
+    function swapTokensForExactTokens(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external override ensure(deadline) returns (uint[] memory amounts) {
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        require(
+            amounts[0] <= amountInMax,
+            "UniswapV2Router: EXCESSIVE_INPUT_AMOUNT"
+        );
+        TransferHelper.safeTransferFrom(
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amounts[0]
+        );
+        _swap(amounts, path, to);
+    }
+
+    function swapExactETHForTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    )
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint[] memory amounts)
+    {
+        require(path[0] == WETH, "UniswapV2Router: INVALID_PATH");
+        amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path);
+        require(
+            amounts[amounts.length - 1] >= amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
+        IWETH(WETH).deposit{value: amounts[0]}();
+        assert(
+            IWETH(WETH).transfer(
+                UniswapV2Library.pairFor(factory, path[0], path[1]),
+                amounts[0]
+            )
+        );
+        _swap(amounts, path, to);
+    }
+
+    function swapTokensForExactETH(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external override ensure(deadline) returns (uint[] memory amounts) {
+        require(path[path.length - 1] == WETH, "UniswapV2Router: INVALID_PATH");
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        require(
+            amounts[0] <= amountInMax,
+            "UniswapV2Router: EXCESSIVE_INPUT_AMOUNT"
+        );
+        TransferHelper.safeTransferFrom(
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amounts[0]
+        );
+        _swap(amounts, path, address(this));
+        IWETH(WETH).withdraw(amounts[amounts.length - 1]);
+        TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+    }
+
+    function swapExactTokensForETH(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external override ensure(deadline) returns (uint[] memory amounts) {
+        require(path[path.length - 1] == WETH, "UniswapV2Router: INVALID_PATH");
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
+        require(
+            amounts[amounts.length - 1] >= amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
+        TransferHelper.safeTransferFrom(
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amounts[0]
+        );
+        _swap(amounts, path, address(this));
+        IWETH(WETH).withdraw(amounts[amounts.length - 1]);
+        TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+    }
+
+    function swapETHForExactTokens(
+        uint amountOut,
+        address[] calldata path,
+        address to,
+        uint deadline
+    )
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint[] memory amounts)
+    {
+        require(path[0] == WETH, "UniswapV2Router: INVALID_PATH");
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        require(
+            amounts[0] <= msg.value,
+            "UniswapV2Router: EXCESSIVE_INPUT_AMOUNT"
+        );
+        IWETH(WETH).deposit{value: amounts[0]}();
+        assert(
+            IWETH(WETH).transfer(
+                UniswapV2Library.pairFor(factory, path[0], path[1]),
+                amounts[0]
+            )
+        );
+        _swap(amounts, path, to);
+        if (msg.value > amounts[0])
+            TransferHelper.safeTransferETH(msg.sender, msg.value - amounts[0]); // refund dust eth, if any
+    }
+
+    function quote(
+        uint amountA,
+        uint reserveA,
+        uint reserveB
+    ) public pure override returns (uint amountB) {
+        return UniswapV2Library.quote(amountA, reserveA, reserveB);
+    }
+
+    function getAmountOut(
+        uint amountIn,
+        uint reserveIn,
+        uint reserveOut
+    ) public pure override returns (uint amountOut) {
+        return UniswapV2Library.getAmountOut(amountIn, reserveIn, reserveOut);
+    }
+
+    function getAmountIn(
+        uint amountOut,
+        uint reserveIn,
+        uint reserveOut
+    ) public pure override returns (uint amountIn) {
+        return UniswapV2Library.getAmountOut(amountOut, reserveIn, reserveOut);
+    }
+
+    function getAmountsOut(
+        uint amountIn,
+        address[] memory path
+    ) public view override returns (uint[] memory amounts) {
+        return UniswapV2Library.getAmountsOut(factory, amountIn, path);
+    }
+
+    function getAmountsIn(
+        uint amountOut,
+        address[] memory path
+    ) public view override returns (uint[] memory amounts) {
+        return UniswapV2Library.getAmountsIn(factory, amountOut, path);
+    }
+}

--- a/contracts/AMM/UniswapV2/uni-v2/UniswapV2Router02.sol
+++ b/contracts/AMM/UniswapV2/uni-v2/UniswapV2Router02.sol
@@ -1,0 +1,446 @@
+pragma solidity =0.6.6;
+
+import '../interfaces/IUniswapV2Factory.sol';
+import '../libraries/TransferHelper.sol';
+
+import '../interfaces/IUniswapV2Router02.sol';
+import '../libraries/UniswapV2Library.sol';
+import '../libraries/SafeMath.sol';
+import '../interfaces/IERC20.sol';
+import '../interfaces/IWETH.sol';
+
+contract UniswapV2Router02 is IUniswapV2Router02 {
+    using SafeMath for uint;
+
+    address public immutable override factory;
+    address public immutable override WETH;
+
+    modifier ensure(uint deadline) {
+        require(deadline >= block.timestamp, 'UniswapV2Router: EXPIRED');
+        _;
+    }
+
+    constructor(address _factory, address _WETH) public {
+        factory = _factory;
+        WETH = _WETH;
+    }
+
+    receive() external payable {
+        assert(msg.sender == WETH); // only accept ETH via fallback from the WETH contract
+    }
+
+    // **** ADD LIQUIDITY ****
+    function _addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin
+    ) internal virtual returns (uint amountA, uint amountB) {
+        // create the pair if it doesn't exist yet
+        if (IUniswapV2Factory(factory).getPair(tokenA, tokenB) == address(0)) {
+            IUniswapV2Factory(factory).createPair(tokenA, tokenB);
+        }
+        (uint reserveA, uint reserveB) = UniswapV2Library.getReserves(factory, tokenA, tokenB);
+        if (reserveA == 0 && reserveB == 0) {
+            (amountA, amountB) = (amountADesired, amountBDesired);
+        } else {
+            uint amountBOptimal = UniswapV2Library.quote(amountADesired, reserveA, reserveB);
+            if (amountBOptimal <= amountBDesired) {
+                require(amountBOptimal >= amountBMin, 'UniswapV2Router: INSUFFICIENT_B_AMOUNT');
+                (amountA, amountB) = (amountADesired, amountBOptimal);
+            } else {
+                uint amountAOptimal = UniswapV2Library.quote(amountBDesired, reserveB, reserveA);
+                assert(amountAOptimal <= amountADesired);
+                require(amountAOptimal >= amountAMin, 'UniswapV2Router: INSUFFICIENT_A_AMOUNT');
+                (amountA, amountB) = (amountAOptimal, amountBDesired);
+            }
+        }
+    }
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint amountADesired,
+        uint amountBDesired,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) external virtual override ensure(deadline) returns (uint amountA, uint amountB, uint liquidity) {
+        (amountA, amountB) = _addLiquidity(tokenA, tokenB, amountADesired, amountBDesired, amountAMin, amountBMin);
+        address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
+        TransferHelper.safeTransferFrom(tokenA, msg.sender, pair, amountA);
+        TransferHelper.safeTransferFrom(tokenB, msg.sender, pair, amountB);
+        liquidity = IUniswapV2Pair(pair).mint(to);
+    }
+    function addLiquidityETH(
+        address token,
+        uint amountTokenDesired,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) external virtual override payable ensure(deadline) returns (uint amountToken, uint amountETH, uint liquidity) {
+        (amountToken, amountETH) = _addLiquidity(
+            token,
+            WETH,
+            amountTokenDesired,
+            msg.value,
+            amountTokenMin,
+            amountETHMin
+        );
+        address pair = UniswapV2Library.pairFor(factory, token, WETH);
+        TransferHelper.safeTransferFrom(token, msg.sender, pair, amountToken);
+        IWETH(WETH).deposit{value: amountETH}();
+        assert(IWETH(WETH).transfer(pair, amountETH));
+        liquidity = IUniswapV2Pair(pair).mint(to);
+        // refund dust eth, if any
+        if (msg.value > amountETH) TransferHelper.safeTransferETH(msg.sender, msg.value - amountETH);
+    }
+
+    // **** REMOVE LIQUIDITY ****
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline
+    ) public virtual override ensure(deadline) returns (uint amountA, uint amountB) {
+        address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
+        IUniswapV2Pair(pair).transferFrom(msg.sender, pair, liquidity); // send liquidity to pair
+        (uint amount0, uint amount1) = IUniswapV2Pair(pair).burn(to);
+        (address token0,) = UniswapV2Library.sortTokens(tokenA, tokenB);
+        (amountA, amountB) = tokenA == token0 ? (amount0, amount1) : (amount1, amount0);
+        require(amountA >= amountAMin, 'UniswapV2Router: INSUFFICIENT_A_AMOUNT');
+        require(amountB >= amountBMin, 'UniswapV2Router: INSUFFICIENT_B_AMOUNT');
+    }
+    function removeLiquidityETH(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) public virtual override ensure(deadline) returns (uint amountToken, uint amountETH) {
+        (amountToken, amountETH) = removeLiquidity(
+            token,
+            WETH,
+            liquidity,
+            amountTokenMin,
+            amountETHMin,
+            address(this),
+            deadline
+        );
+        TransferHelper.safeTransfer(token, to, amountToken);
+        IWETH(WETH).withdraw(amountETH);
+        TransferHelper.safeTransferETH(to, amountETH);
+    }
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint liquidity,
+        uint amountAMin,
+        uint amountBMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external virtual override returns (uint amountA, uint amountB) {
+        address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
+        uint value = approveMax ? uint(-1) : liquidity;
+        IUniswapV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
+        (amountA, amountB) = removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to, deadline);
+    }
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external virtual override returns (uint amountToken, uint amountETH) {
+        address pair = UniswapV2Library.pairFor(factory, token, WETH);
+        uint value = approveMax ? uint(-1) : liquidity;
+        IUniswapV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
+        (amountToken, amountETH) = removeLiquidityETH(token, liquidity, amountTokenMin, amountETHMin, to, deadline);
+    }
+
+    // **** REMOVE LIQUIDITY (supporting fee-on-transfer tokens) ****
+    function removeLiquidityETHSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline
+    ) public virtual override ensure(deadline) returns (uint amountETH) {
+        (, amountETH) = removeLiquidity(
+            token,
+            WETH,
+            liquidity,
+            amountTokenMin,
+            amountETHMin,
+            address(this),
+            deadline
+        );
+        TransferHelper.safeTransfer(token, to, IERC20(token).balanceOf(address(this)));
+        IWETH(WETH).withdraw(amountETH);
+        TransferHelper.safeTransferETH(to, amountETH);
+    }
+    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        uint liquidity,
+        uint amountTokenMin,
+        uint amountETHMin,
+        address to,
+        uint deadline,
+        bool approveMax, uint8 v, bytes32 r, bytes32 s
+    ) external virtual override returns (uint amountETH) {
+        address pair = UniswapV2Library.pairFor(factory, token, WETH);
+        uint value = approveMax ? uint(-1) : liquidity;
+        IUniswapV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
+        amountETH = removeLiquidityETHSupportingFeeOnTransferTokens(
+            token, liquidity, amountTokenMin, amountETHMin, to, deadline
+        );
+    }
+
+    // **** SWAP ****
+    // requires the initial amount to have already been sent to the first pair
+    function _swap(uint[] memory amounts, address[] memory path, address _to) internal virtual {
+        for (uint i; i < path.length - 1; i++) {
+            (address input, address output) = (path[i], path[i + 1]);
+            (address token0,) = UniswapV2Library.sortTokens(input, output);
+            uint amountOut = amounts[i + 1];
+            (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOut) : (amountOut, uint(0));
+            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
+            IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output)).swap(
+                amount0Out, amount1Out, to, new bytes(0)
+            );
+        }
+    }
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external virtual override ensure(deadline) returns (uint[] memory amounts) {
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
+        require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        TransferHelper.safeTransferFrom(
+            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
+        );
+        _swap(amounts, path, to);
+    }
+    function swapTokensForExactTokens(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external virtual override ensure(deadline) returns (uint[] memory amounts) {
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
+        TransferHelper.safeTransferFrom(
+            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
+        );
+        _swap(amounts, path, to);
+    }
+    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        virtual
+        override
+        payable
+        ensure(deadline)
+        returns (uint[] memory amounts)
+    {
+        require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
+        amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path);
+        require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        IWETH(WETH).deposit{value: amounts[0]}();
+        assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
+        _swap(amounts, path, to);
+    }
+    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+        external
+        virtual
+        override
+        ensure(deadline)
+        returns (uint[] memory amounts)
+    {
+        require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
+        TransferHelper.safeTransferFrom(
+            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
+        );
+        _swap(amounts, path, address(this));
+        IWETH(WETH).withdraw(amounts[amounts.length - 1]);
+        TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+    }
+    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+        external
+        virtual
+        override
+        ensure(deadline)
+        returns (uint[] memory amounts)
+    {
+        require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
+        amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
+        require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        TransferHelper.safeTransferFrom(
+            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
+        );
+        _swap(amounts, path, address(this));
+        IWETH(WETH).withdraw(amounts[amounts.length - 1]);
+        TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+    }
+    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+        external
+        virtual
+        override
+        payable
+        ensure(deadline)
+        returns (uint[] memory amounts)
+    {
+        require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        require(amounts[0] <= msg.value, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
+        IWETH(WETH).deposit{value: amounts[0]}();
+        assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
+        _swap(amounts, path, to);
+        // refund dust eth, if any
+        if (msg.value > amounts[0]) TransferHelper.safeTransferETH(msg.sender, msg.value - amounts[0]);
+    }
+
+    // **** SWAP (supporting fee-on-transfer tokens) ****
+    // requires the initial amount to have already been sent to the first pair
+    function _swapSupportingFeeOnTransferTokens(address[] memory path, address _to) internal virtual {
+        for (uint i; i < path.length - 1; i++) {
+            (address input, address output) = (path[i], path[i + 1]);
+            (address token0,) = UniswapV2Library.sortTokens(input, output);
+            IUniswapV2Pair pair = IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output));
+            uint amountInput;
+            uint amountOutput;
+            { // scope to avoid stack too deep errors
+            (uint reserve0, uint reserve1,) = pair.getReserves();
+            (uint reserveInput, uint reserveOutput) = input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+            amountInput = IERC20(input).balanceOf(address(pair)).sub(reserveInput);
+            amountOutput = UniswapV2Library.getAmountOut(amountInput, reserveInput, reserveOutput);
+            }
+            (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOutput) : (amountOutput, uint(0));
+            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
+            pair.swap(amount0Out, amount1Out, to, new bytes(0));
+        }
+    }
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external virtual override ensure(deadline) {
+        TransferHelper.safeTransferFrom(
+            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amountIn
+        );
+        uint balanceBefore = IERC20(path[path.length - 1]).balanceOf(to);
+        _swapSupportingFeeOnTransferTokens(path, to);
+        require(
+            IERC20(path[path.length - 1]).balanceOf(to).sub(balanceBefore) >= amountOutMin,
+            'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT'
+        );
+    }
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    )
+        external
+        virtual
+        override
+        payable
+        ensure(deadline)
+    {
+        require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
+        uint amountIn = msg.value;
+        IWETH(WETH).deposit{value: amountIn}();
+        assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amountIn));
+        uint balanceBefore = IERC20(path[path.length - 1]).balanceOf(to);
+        _swapSupportingFeeOnTransferTokens(path, to);
+        require(
+            IERC20(path[path.length - 1]).balanceOf(to).sub(balanceBefore) >= amountOutMin,
+            'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT'
+        );
+    }
+    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    )
+        external
+        virtual
+        override
+        ensure(deadline)
+    {
+        require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
+        TransferHelper.safeTransferFrom(
+            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amountIn
+        );
+        _swapSupportingFeeOnTransferTokens(path, address(this));
+        uint amountOut = IERC20(WETH).balanceOf(address(this));
+        require(amountOut >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        IWETH(WETH).withdraw(amountOut);
+        TransferHelper.safeTransferETH(to, amountOut);
+    }
+
+    // **** LIBRARY FUNCTIONS ****
+    function quote(uint amountA, uint reserveA, uint reserveB) public pure virtual override returns (uint amountB) {
+        return UniswapV2Library.quote(amountA, reserveA, reserveB);
+    }
+
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut)
+        public
+        pure
+        virtual
+        override
+        returns (uint amountOut)
+    {
+        return UniswapV2Library.getAmountOut(amountIn, reserveIn, reserveOut);
+    }
+
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut)
+        public
+        pure
+        virtual
+        override
+        returns (uint amountIn)
+    {
+        return UniswapV2Library.getAmountIn(amountOut, reserveIn, reserveOut);
+    }
+
+    function getAmountsOut(uint amountIn, address[] memory path)
+        public
+        view
+        virtual
+        override
+        returns (uint[] memory amounts)
+    {
+        return UniswapV2Library.getAmountsOut(factory, amountIn, path);
+    }
+
+    function getAmountsIn(uint amountOut, address[] memory path)
+        public
+        view
+        virtual
+        override
+        returns (uint[] memory amounts)
+    {
+        return UniswapV2Library.getAmountsIn(factory, amountOut, path);
+    }
+}

--- a/contracts/AMM/UniswapV2/uni-v2/UniswapV2Router02.sol
+++ b/contracts/AMM/UniswapV2/uni-v2/UniswapV2Router02.sol
@@ -1,13 +1,13 @@
 pragma solidity =0.6.6;
 
-import '../interfaces/IUniswapV2Factory.sol';
-import '../libraries/TransferHelper.sol';
+import "../interfaces/IUniswapV2Factory.sol";
+import "../libraries/TransferHelper.sol";
 
-import '../interfaces/IUniswapV2Router02.sol';
-import '../libraries/UniswapV2Library.sol';
-import '../libraries/SafeMath.sol';
-import '../interfaces/IERC20.sol';
-import '../interfaces/IWETH.sol';
+import "../interfaces/IUniswapV2Router02.sol";
+import "../libraries/UniswapV2Library.sol";
+import "../libraries/SafeMath.sol";
+import "../interfaces/IERC20.sol";
+import "../interfaces/IWETH.sol";
 
 contract UniswapV2Router02 is IUniswapV2Router02 {
     using SafeMath for uint;
@@ -16,7 +16,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
     address public immutable override WETH;
 
     modifier ensure(uint deadline) {
-        require(deadline >= block.timestamp, 'UniswapV2Router: EXPIRED');
+        require(deadline >= block.timestamp, "UniswapV2Router: EXPIRED");
         _;
     }
 
@@ -42,22 +42,41 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         if (IUniswapV2Factory(factory).getPair(tokenA, tokenB) == address(0)) {
             IUniswapV2Factory(factory).createPair(tokenA, tokenB);
         }
-        (uint reserveA, uint reserveB) = UniswapV2Library.getReserves(factory, tokenA, tokenB);
+        (uint reserveA, uint reserveB) = UniswapV2Library.getReserves(
+            factory,
+            tokenA,
+            tokenB
+        );
         if (reserveA == 0 && reserveB == 0) {
             (amountA, amountB) = (amountADesired, amountBDesired);
         } else {
-            uint amountBOptimal = UniswapV2Library.quote(amountADesired, reserveA, reserveB);
+            uint amountBOptimal = UniswapV2Library.quote(
+                amountADesired,
+                reserveA,
+                reserveB
+            );
             if (amountBOptimal <= amountBDesired) {
-                require(amountBOptimal >= amountBMin, 'UniswapV2Router: INSUFFICIENT_B_AMOUNT');
+                require(
+                    amountBOptimal >= amountBMin,
+                    "UniswapV2Router: INSUFFICIENT_B_AMOUNT"
+                );
                 (amountA, amountB) = (amountADesired, amountBOptimal);
             } else {
-                uint amountAOptimal = UniswapV2Library.quote(amountBDesired, reserveB, reserveA);
+                uint amountAOptimal = UniswapV2Library.quote(
+                    amountBDesired,
+                    reserveB,
+                    reserveA
+                );
                 assert(amountAOptimal <= amountADesired);
-                require(amountAOptimal >= amountAMin, 'UniswapV2Router: INSUFFICIENT_A_AMOUNT');
+                require(
+                    amountAOptimal >= amountAMin,
+                    "UniswapV2Router: INSUFFICIENT_A_AMOUNT"
+                );
                 (amountA, amountB) = (amountAOptimal, amountBDesired);
             }
         }
     }
+
     function addLiquidity(
         address tokenA,
         address tokenB,
@@ -67,13 +86,27 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         uint amountBMin,
         address to,
         uint deadline
-    ) external virtual override ensure(deadline) returns (uint amountA, uint amountB, uint liquidity) {
-        (amountA, amountB) = _addLiquidity(tokenA, tokenB, amountADesired, amountBDesired, amountAMin, amountBMin);
+    )
+        external
+        virtual
+        override
+        ensure(deadline)
+        returns (uint amountA, uint amountB, uint liquidity)
+    {
+        (amountA, amountB) = _addLiquidity(
+            tokenA,
+            tokenB,
+            amountADesired,
+            amountBDesired,
+            amountAMin,
+            amountBMin
+        );
         address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
         TransferHelper.safeTransferFrom(tokenA, msg.sender, pair, amountA);
         TransferHelper.safeTransferFrom(tokenB, msg.sender, pair, amountB);
         liquidity = IUniswapV2Pair(pair).mint(to);
     }
+
     function addLiquidityETH(
         address token,
         uint amountTokenDesired,
@@ -81,7 +114,14 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         uint amountETHMin,
         address to,
         uint deadline
-    ) external virtual override payable ensure(deadline) returns (uint amountToken, uint amountETH, uint liquidity) {
+    )
+        external
+        payable
+        virtual
+        override
+        ensure(deadline)
+        returns (uint amountToken, uint amountETH, uint liquidity)
+    {
         (amountToken, amountETH) = _addLiquidity(
             token,
             WETH,
@@ -96,7 +136,8 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         assert(IWETH(WETH).transfer(pair, amountETH));
         liquidity = IUniswapV2Pair(pair).mint(to);
         // refund dust eth, if any
-        if (msg.value > amountETH) TransferHelper.safeTransferETH(msg.sender, msg.value - amountETH);
+        if (msg.value > amountETH)
+            TransferHelper.safeTransferETH(msg.sender, msg.value - amountETH);
     }
 
     // **** REMOVE LIQUIDITY ****
@@ -108,15 +149,30 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         uint amountBMin,
         address to,
         uint deadline
-    ) public virtual override ensure(deadline) returns (uint amountA, uint amountB) {
+    )
+        public
+        virtual
+        override
+        ensure(deadline)
+        returns (uint amountA, uint amountB)
+    {
         address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
         IUniswapV2Pair(pair).transferFrom(msg.sender, pair, liquidity); // send liquidity to pair
         (uint amount0, uint amount1) = IUniswapV2Pair(pair).burn(to);
-        (address token0,) = UniswapV2Library.sortTokens(tokenA, tokenB);
-        (amountA, amountB) = tokenA == token0 ? (amount0, amount1) : (amount1, amount0);
-        require(amountA >= amountAMin, 'UniswapV2Router: INSUFFICIENT_A_AMOUNT');
-        require(amountB >= amountBMin, 'UniswapV2Router: INSUFFICIENT_B_AMOUNT');
+        (address token0, ) = UniswapV2Library.sortTokens(tokenA, tokenB);
+        (amountA, amountB) = tokenA == token0
+            ? (amount0, amount1)
+            : (amount1, amount0);
+        require(
+            amountA >= amountAMin,
+            "UniswapV2Router: INSUFFICIENT_A_AMOUNT"
+        );
+        require(
+            amountB >= amountBMin,
+            "UniswapV2Router: INSUFFICIENT_B_AMOUNT"
+        );
     }
+
     function removeLiquidityETH(
         address token,
         uint liquidity,
@@ -124,7 +180,13 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         uint amountETHMin,
         address to,
         uint deadline
-    ) public virtual override ensure(deadline) returns (uint amountToken, uint amountETH) {
+    )
+        public
+        virtual
+        override
+        ensure(deadline)
+        returns (uint amountToken, uint amountETH)
+    {
         (amountToken, amountETH) = removeLiquidity(
             token,
             WETH,
@@ -138,6 +200,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         IWETH(WETH).withdraw(amountETH);
         TransferHelper.safeTransferETH(to, amountETH);
     }
+
     function removeLiquidityWithPermit(
         address tokenA,
         address tokenB,
@@ -146,13 +209,33 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         uint amountBMin,
         address to,
         uint deadline,
-        bool approveMax, uint8 v, bytes32 r, bytes32 s
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
     ) external virtual override returns (uint amountA, uint amountB) {
         address pair = UniswapV2Library.pairFor(factory, tokenA, tokenB);
         uint value = approveMax ? uint(-1) : liquidity;
-        IUniswapV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
-        (amountA, amountB) = removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to, deadline);
+        IUniswapV2Pair(pair).permit(
+            msg.sender,
+            address(this),
+            value,
+            deadline,
+            v,
+            r,
+            s
+        );
+        (amountA, amountB) = removeLiquidity(
+            tokenA,
+            tokenB,
+            liquidity,
+            amountAMin,
+            amountBMin,
+            to,
+            deadline
+        );
     }
+
     function removeLiquidityETHWithPermit(
         address token,
         uint liquidity,
@@ -160,12 +243,30 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         uint amountETHMin,
         address to,
         uint deadline,
-        bool approveMax, uint8 v, bytes32 r, bytes32 s
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
     ) external virtual override returns (uint amountToken, uint amountETH) {
         address pair = UniswapV2Library.pairFor(factory, token, WETH);
         uint value = approveMax ? uint(-1) : liquidity;
-        IUniswapV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
-        (amountToken, amountETH) = removeLiquidityETH(token, liquidity, amountTokenMin, amountETHMin, to, deadline);
+        IUniswapV2Pair(pair).permit(
+            msg.sender,
+            address(this),
+            value,
+            deadline,
+            v,
+            r,
+            s
+        );
+        (amountToken, amountETH) = removeLiquidityETH(
+            token,
+            liquidity,
+            amountTokenMin,
+            amountETHMin,
+            to,
+            deadline
+        );
     }
 
     // **** REMOVE LIQUIDITY (supporting fee-on-transfer tokens) ****
@@ -186,10 +287,15 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
             address(this),
             deadline
         );
-        TransferHelper.safeTransfer(token, to, IERC20(token).balanceOf(address(this)));
+        TransferHelper.safeTransfer(
+            token,
+            to,
+            IERC20(token).balanceOf(address(this))
+        );
         IWETH(WETH).withdraw(amountETH);
         TransferHelper.safeTransferETH(to, amountETH);
     }
+
     function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
         address token,
         uint liquidity,
@@ -197,145 +303,268 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         uint amountETHMin,
         address to,
         uint deadline,
-        bool approveMax, uint8 v, bytes32 r, bytes32 s
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
     ) external virtual override returns (uint amountETH) {
         address pair = UniswapV2Library.pairFor(factory, token, WETH);
         uint value = approveMax ? uint(-1) : liquidity;
-        IUniswapV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
+        IUniswapV2Pair(pair).permit(
+            msg.sender,
+            address(this),
+            value,
+            deadline,
+            v,
+            r,
+            s
+        );
         amountETH = removeLiquidityETHSupportingFeeOnTransferTokens(
-            token, liquidity, amountTokenMin, amountETHMin, to, deadline
+            token,
+            liquidity,
+            amountTokenMin,
+            amountETHMin,
+            to,
+            deadline
         );
     }
 
     // **** SWAP ****
     // requires the initial amount to have already been sent to the first pair
-    function _swap(uint[] memory amounts, address[] memory path, address _to) internal virtual {
+    function _swap(
+        uint[] memory amounts,
+        address[] memory path,
+        address _to
+    ) internal virtual {
         for (uint i; i < path.length - 1; i++) {
             (address input, address output) = (path[i], path[i + 1]);
-            (address token0,) = UniswapV2Library.sortTokens(input, output);
+            (address token0, ) = UniswapV2Library.sortTokens(input, output);
             uint amountOut = amounts[i + 1];
-            (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOut) : (amountOut, uint(0));
-            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
-            IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output)).swap(
-                amount0Out, amount1Out, to, new bytes(0)
-            );
+            (uint amount0Out, uint amount1Out) = input == token0
+                ? (uint(0), amountOut)
+                : (amountOut, uint(0));
+            address to = i < path.length - 2
+                ? UniswapV2Library.pairFor(factory, output, path[i + 2])
+                : _to;
+            IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output))
+                .swap(amount0Out, amount1Out, to, new bytes(0));
         }
     }
+
     function swapExactTokensForTokens(
         uint amountIn,
         uint amountOutMin,
         address[] calldata path,
         address to,
         uint deadline
-    ) external virtual override ensure(deadline) returns (uint[] memory amounts) {
+    )
+        external
+        virtual
+        override
+        ensure(deadline)
+        returns (uint[] memory amounts)
+    {
         amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
-        require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(
+            amounts[amounts.length - 1] >= amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
         TransferHelper.safeTransferFrom(
-            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amounts[0]
         );
         _swap(amounts, path, to);
     }
+
     function swapTokensForExactTokens(
         uint amountOut,
         uint amountInMax,
         address[] calldata path,
         address to,
         uint deadline
-    ) external virtual override ensure(deadline) returns (uint[] memory amounts) {
-        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
-        require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
-        TransferHelper.safeTransferFrom(
-            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
-        );
-        _swap(amounts, path, to);
-    }
-    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+    )
         external
         virtual
         override
-        payable
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
+        amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
+        require(
+            amounts[0] <= amountInMax,
+            "UniswapV2Router: EXCESSIVE_INPUT_AMOUNT"
+        );
+        TransferHelper.safeTransferFrom(
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amounts[0]
+        );
+        _swap(amounts, path, to);
+    }
+
+    function swapExactETHForTokens(
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    )
+        external
+        payable
+        virtual
+        override
+        ensure(deadline)
+        returns (uint[] memory amounts)
+    {
+        require(path[0] == WETH, "UniswapV2Router: INVALID_PATH");
         amounts = UniswapV2Library.getAmountsOut(factory, msg.value, path);
-        require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(
+            amounts[amounts.length - 1] >= amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
         IWETH(WETH).deposit{value: amounts[0]}();
-        assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
+        assert(
+            IWETH(WETH).transfer(
+                UniswapV2Library.pairFor(factory, path[0], path[1]),
+                amounts[0]
+            )
+        );
         _swap(amounts, path, to);
     }
-    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+
+    function swapTokensForExactETH(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to,
+        uint deadline
+    )
         external
         virtual
         override
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
+        require(path[path.length - 1] == WETH, "UniswapV2Router: INVALID_PATH");
         amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
-        require(amounts[0] <= amountInMax, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
+        require(
+            amounts[0] <= amountInMax,
+            "UniswapV2Router: EXCESSIVE_INPUT_AMOUNT"
+        );
         TransferHelper.safeTransferFrom(
-            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amounts[0]
         );
         _swap(amounts, path, address(this));
         IWETH(WETH).withdraw(amounts[amounts.length - 1]);
         TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
     }
-    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+
+    function swapExactTokensForETH(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    )
         external
         virtual
         override
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
+        require(path[path.length - 1] == WETH, "UniswapV2Router: INVALID_PATH");
         amounts = UniswapV2Library.getAmountsOut(factory, amountIn, path);
-        require(amounts[amounts.length - 1] >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(
+            amounts[amounts.length - 1] >= amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
         TransferHelper.safeTransferFrom(
-            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amounts[0]
         );
         _swap(amounts, path, address(this));
         IWETH(WETH).withdraw(amounts[amounts.length - 1]);
         TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
     }
-    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+
+    function swapETHForExactTokens(
+        uint amountOut,
+        address[] calldata path,
+        address to,
+        uint deadline
+    )
         external
+        payable
         virtual
         override
-        payable
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
+        require(path[0] == WETH, "UniswapV2Router: INVALID_PATH");
         amounts = UniswapV2Library.getAmountsIn(factory, amountOut, path);
-        require(amounts[0] <= msg.value, 'UniswapV2Router: EXCESSIVE_INPUT_AMOUNT');
+        require(
+            amounts[0] <= msg.value,
+            "UniswapV2Router: EXCESSIVE_INPUT_AMOUNT"
+        );
         IWETH(WETH).deposit{value: amounts[0]}();
-        assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
+        assert(
+            IWETH(WETH).transfer(
+                UniswapV2Library.pairFor(factory, path[0], path[1]),
+                amounts[0]
+            )
+        );
         _swap(amounts, path, to);
         // refund dust eth, if any
-        if (msg.value > amounts[0]) TransferHelper.safeTransferETH(msg.sender, msg.value - amounts[0]);
+        if (msg.value > amounts[0])
+            TransferHelper.safeTransferETH(msg.sender, msg.value - amounts[0]);
     }
 
     // **** SWAP (supporting fee-on-transfer tokens) ****
     // requires the initial amount to have already been sent to the first pair
-    function _swapSupportingFeeOnTransferTokens(address[] memory path, address _to) internal virtual {
+    function _swapSupportingFeeOnTransferTokens(
+        address[] memory path,
+        address _to
+    ) internal virtual {
         for (uint i; i < path.length - 1; i++) {
             (address input, address output) = (path[i], path[i + 1]);
-            (address token0,) = UniswapV2Library.sortTokens(input, output);
-            IUniswapV2Pair pair = IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output));
+            (address token0, ) = UniswapV2Library.sortTokens(input, output);
+            IUniswapV2Pair pair = IUniswapV2Pair(
+                UniswapV2Library.pairFor(factory, input, output)
+            );
             uint amountInput;
             uint amountOutput;
-            { // scope to avoid stack too deep errors
-            (uint reserve0, uint reserve1,) = pair.getReserves();
-            (uint reserveInput, uint reserveOutput) = input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
-            amountInput = IERC20(input).balanceOf(address(pair)).sub(reserveInput);
-            amountOutput = UniswapV2Library.getAmountOut(amountInput, reserveInput, reserveOutput);
+            {
+                // scope to avoid stack too deep errors
+                (uint reserve0, uint reserve1, ) = pair.getReserves();
+                (uint reserveInput, uint reserveOutput) = input == token0
+                    ? (reserve0, reserve1)
+                    : (reserve1, reserve0);
+                amountInput = IERC20(input).balanceOf(address(pair)).sub(
+                    reserveInput
+                );
+                amountOutput = UniswapV2Library.getAmountOut(
+                    amountInput,
+                    reserveInput,
+                    reserveOutput
+                );
             }
-            (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOutput) : (amountOutput, uint(0));
-            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
+            (uint amount0Out, uint amount1Out) = input == token0
+                ? (uint(0), amountOutput)
+                : (amountOutput, uint(0));
+            address to = i < path.length - 2
+                ? UniswapV2Library.pairFor(factory, output, path[i + 2])
+                : _to;
             pair.swap(amount0Out, amount1Out, to, new bytes(0));
         }
     }
+
     function swapExactTokensForTokensSupportingFeeOnTransferTokens(
         uint amountIn,
         uint amountOutMin,
@@ -344,103 +573,104 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         uint deadline
     ) external virtual override ensure(deadline) {
         TransferHelper.safeTransferFrom(
-            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amountIn
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amountIn
         );
         uint balanceBefore = IERC20(path[path.length - 1]).balanceOf(to);
         _swapSupportingFeeOnTransferTokens(path, to);
         require(
-            IERC20(path[path.length - 1]).balanceOf(to).sub(balanceBefore) >= amountOutMin,
-            'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT'
+            IERC20(path[path.length - 1]).balanceOf(to).sub(balanceBefore) >=
+                amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
         );
     }
+
     function swapExactETHForTokensSupportingFeeOnTransferTokens(
         uint amountOutMin,
         address[] calldata path,
         address to,
         uint deadline
-    )
-        external
-        virtual
-        override
-        payable
-        ensure(deadline)
-    {
-        require(path[0] == WETH, 'UniswapV2Router: INVALID_PATH');
+    ) external payable virtual override ensure(deadline) {
+        require(path[0] == WETH, "UniswapV2Router: INVALID_PATH");
         uint amountIn = msg.value;
         IWETH(WETH).deposit{value: amountIn}();
-        assert(IWETH(WETH).transfer(UniswapV2Library.pairFor(factory, path[0], path[1]), amountIn));
+        assert(
+            IWETH(WETH).transfer(
+                UniswapV2Library.pairFor(factory, path[0], path[1]),
+                amountIn
+            )
+        );
         uint balanceBefore = IERC20(path[path.length - 1]).balanceOf(to);
         _swapSupportingFeeOnTransferTokens(path, to);
         require(
-            IERC20(path[path.length - 1]).balanceOf(to).sub(balanceBefore) >= amountOutMin,
-            'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT'
+            IERC20(path[path.length - 1]).balanceOf(to).sub(balanceBefore) >=
+                amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
         );
     }
+
     function swapExactTokensForETHSupportingFeeOnTransferTokens(
         uint amountIn,
         uint amountOutMin,
         address[] calldata path,
         address to,
         uint deadline
-    )
-        external
-        virtual
-        override
-        ensure(deadline)
-    {
-        require(path[path.length - 1] == WETH, 'UniswapV2Router: INVALID_PATH');
+    ) external virtual override ensure(deadline) {
+        require(path[path.length - 1] == WETH, "UniswapV2Router: INVALID_PATH");
         TransferHelper.safeTransferFrom(
-            path[0], msg.sender, UniswapV2Library.pairFor(factory, path[0], path[1]), amountIn
+            path[0],
+            msg.sender,
+            UniswapV2Library.pairFor(factory, path[0], path[1]),
+            amountIn
         );
         _swapSupportingFeeOnTransferTokens(path, address(this));
         uint amountOut = IERC20(WETH).balanceOf(address(this));
-        require(amountOut >= amountOutMin, 'UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(
+            amountOut >= amountOutMin,
+            "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT"
+        );
         IWETH(WETH).withdraw(amountOut);
         TransferHelper.safeTransferETH(to, amountOut);
     }
 
     // **** LIBRARY FUNCTIONS ****
-    function quote(uint amountA, uint reserveA, uint reserveB) public pure virtual override returns (uint amountB) {
+    function quote(
+        uint amountA,
+        uint reserveA,
+        uint reserveB
+    ) public pure virtual override returns (uint amountB) {
         return UniswapV2Library.quote(amountA, reserveA, reserveB);
     }
 
-    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut)
-        public
-        pure
-        virtual
-        override
-        returns (uint amountOut)
-    {
+    function getAmountOut(
+        uint amountIn,
+        uint reserveIn,
+        uint reserveOut
+    ) public pure virtual override returns (uint amountOut) {
         return UniswapV2Library.getAmountOut(amountIn, reserveIn, reserveOut);
     }
 
-    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut)
-        public
-        pure
-        virtual
-        override
-        returns (uint amountIn)
-    {
+    function getAmountIn(
+        uint amountOut,
+        uint reserveIn,
+        uint reserveOut
+    ) public pure virtual override returns (uint amountIn) {
         return UniswapV2Library.getAmountIn(amountOut, reserveIn, reserveOut);
     }
 
-    function getAmountsOut(uint amountIn, address[] memory path)
-        public
-        view
-        virtual
-        override
-        returns (uint[] memory amounts)
-    {
+    function getAmountsOut(
+        uint amountIn,
+        address[] memory path
+    ) public view virtual override returns (uint[] memory amounts) {
         return UniswapV2Library.getAmountsOut(factory, amountIn, path);
     }
 
-    function getAmountsIn(uint amountOut, address[] memory path)
-        public
-        view
-        virtual
-        override
-        returns (uint[] memory amounts)
-    {
+    function getAmountsIn(
+        uint amountOut,
+        address[] memory path
+    ) public view virtual override returns (uint[] memory amounts) {
         return UniswapV2Library.getAmountsIn(factory, amountOut, path);
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -10,6 +10,24 @@ module.exports = {
   solidity: {
     compilers: [
       {
+        version: "0.5.16",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+      {
+        version: "0.6.6",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+      {
         version: "0.8.1",
         settings: {
           optimizer: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/contracts": "^4.7.3",
+        "@uniswap/v2-core": "^1.0.1",
+        "@uniswap/v2-periphery": "^1.1.0-beta.0",
         "markdown-link-check": "^3.11.0",
         "prettier": "^2.8.7",
         "prettier-plugin-solidity": "^1.1.3",
@@ -1225,6 +1227,42 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@uniswap/lib": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-1.1.1.tgz",
+      "integrity": "sha512-2yK7sLpKIT91TiS5sewHtOa7YuM8IuBXVl4GZv2jZFys4D2sY7K5vZh6MqD25TPA95Od+0YzCVq6cTF2IKrOmg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.1.tgz",
+      "integrity": "sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-periphery": {
+      "version": "1.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-periphery/-/v2-periphery-1.1.0-beta.0.tgz",
+      "integrity": "sha512-6dkwAMKza8nzqYiXEr2D86dgW3TTavUvCR0w2Tu33bAbM8Ah43LKAzH7oKKPRT5VJQaMi1jtkGs1E8JPor1n5g==",
+      "dependencies": {
+        "@uniswap/lib": "1.1.1",
+        "@uniswap/v2-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-periphery/node_modules/@uniswap/v2-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.0.tgz",
+      "integrity": "sha512-BJiXrBGnN8mti7saW49MXwxDBRFiWemGetE58q8zgfnPPzQKq55ADltEILqOt6VFZ22kVeVKbF8gVd8aY3l7pA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/abort-controller": {
@@ -5240,6 +5278,32 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@uniswap/lib": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/lib/-/lib-1.1.1.tgz",
+      "integrity": "sha512-2yK7sLpKIT91TiS5sewHtOa7YuM8IuBXVl4GZv2jZFys4D2sY7K5vZh6MqD25TPA95Od+0YzCVq6cTF2IKrOmg=="
+    },
+    "@uniswap/v2-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.1.tgz",
+      "integrity": "sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q=="
+    },
+    "@uniswap/v2-periphery": {
+      "version": "1.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@uniswap/v2-periphery/-/v2-periphery-1.1.0-beta.0.tgz",
+      "integrity": "sha512-6dkwAMKza8nzqYiXEr2D86dgW3TTavUvCR0w2Tu33bAbM8Ah43LKAzH7oKKPRT5VJQaMi1jtkGs1E8JPor1n5g==",
+      "requires": {
+        "@uniswap/lib": "1.1.1",
+        "@uniswap/v2-core": "1.0.0"
+      },
+      "dependencies": {
+        "@uniswap/v2-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@uniswap/v2-core/-/v2-core-1.0.0.tgz",
+          "integrity": "sha512-BJiXrBGnN8mti7saW49MXwxDBRFiWemGetE58q8zgfnPPzQKq55ADltEILqOt6VFZ22kVeVKbF8gVd8aY3l7pA=="
+        }
       }
     },
     "abort-controller": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format-embedded-solidity": "prettier --write \"**/*.md\" --embedded-language-formatting=auto --plugin prettier-plugin-solidity --tab-width 4 --print-width 120 && prettier --write \"**/*.md\"",
     "lint": "npm run lint-check-format && npm run lint-check-links",
     "lint-check-format": "prettier --check .",
-    "lint-check-links": "find . -name '*.md' -not -path './node_modules/*' -print0 | xargs -0 -n1 markdown-link-check"
+    "lint-check-links": "find . -name '*.md' -not -path './node_modules/*' -print0 | xargs -0 -n1 markdown-link-check",
+    "echidna-univ2": "echidna . --contract CryticUniswapV2PropertyTests --config ./contracts/AMM/UniswapV2/echidna-config.yaml"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "npm run lint-check-format && npm run lint-check-links",
     "lint-check-format": "prettier --check .",
     "lint-check-links": "find . -name '*.md' -not -path './node_modules/*' -print0 | xargs -0 -n1 markdown-link-check",
-    "echidna-univ2": "echidna . --contract CryticUniswapV2PropertyTests --config ./contracts/AMM/UniswapV2/echidna-config.yaml"
+    "echidna-univ2": "echidna . --contract CryticUniswapV2PropertyTests --config ./contracts/AMM/UniswapV2/echidna-config.yaml",
+    "echidna-univ2-router": "echidna . --contract CryticUniswapV2RouterPropertyTests --config ./contracts/AMM/UniswapV2/echidna-config.yaml"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   "homepage": "https://github.com/crytic/properties#readme",
   "dependencies": {
     "@openzeppelin/contracts": "^4.7.3",
+    "@uniswap/v2-core": "^1.0.1",
+    "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "markdown-link-check": "^3.11.0",
     "prettier": "^2.8.7",
     "prettier-plugin-solidity": "^1.1.3",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,6 @@
+ERC4626/=lib/ERC4626/contracts/
+ds-test/=lib/forge-std/lib/ds-test/src/
+erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/
+forge-std/=lib/forge-std/src/
+@openzeppelin/=lib/openzeppelin-contracts/
+solmate/=lib/solmate/


### PR DESCRIPTION
Initial draft of UniswapV2 basic properties.

**Providing liquidity**

- always increases K
- always increases LP token supply
- always increases user LP token supply
- never impacts token prices
- always increases token reserves

**Withdrawing liquidity**

- always decreases K
- always decreases LP token supply
- always decreases user LP token supply
- never impacts token prices
- always decreases token reserves

**Swapping**

- never decreases K
- swapping in both directions does not result in tokens gained
- always increases user token out balance
- price of tokenIn always decreases
- price of tokenOut always increases

**Blockers:** Properties fail with `ErrorUnrecognizedOpcode` https://github.com/crytic/echidna/issues/984, so far haven't been able to figure out why
**Cons:** Only tests UniswapV2 pair and router. Next step will be to generalize this so the properties can be easily used in a harness for testing UniV2-based AMMs