### PR TITLE
Fix TestERC20Token decimals type (uint256->uint8)

### DIFF
--- a/contracts/ERC4626/util/TestERC20Token.sol
+++ b/contracts/ERC4626/util/TestERC20Token.sol
@@ -1,21 +1,16 @@
 pragma solidity ^0.8.0;
 
-contract TestERC20Token {
-    event Transfer(address indexed from, address indexed to, uint256 amount);
-    event Approval(
-        address indexed owner,
-        address indexed spender,
-        uint256 amount
-    );
+import {IERC20} from "../../util/IERC20.sol";
 
+contract TestERC20Token is IERC20 {
     string public name;
     string public symbol;
-    uint256 public decimals;
+    uint8 public decimals;
     uint256 public totalSupply;
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping(address => uint256)) public allowance;
 
-    constructor(string memory _name, string memory _symbol, uint256 _decimals) {
+    constructor(string memory _name, string memory _symbol, uint8 _decimals) {
         name = _name;
         symbol = _symbol;
         decimals = _decimals;


### PR DESCRIPTION
Fixes `TestERC20Token.decimals` ERC-20 type (from `uint256` to `uint8`)