### PR TITLE
chore: add SPDX license identifiers for files missing them

### DIFF
--- a/contracts/ERC20/external/ERC20ExternalPropertyTests.sol
+++ b/contracts/ERC20/external/ERC20ExternalPropertyTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "./TokenMock.sol";

--- a/contracts/ERC20/external/ExampleToken.sol
+++ b/contracts/ERC20/external/ExampleToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/ERC20/external/TokenMock.sol
+++ b/contracts/ERC20/external/TokenMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "../../util/PropertiesConstants.sol";

--- a/contracts/ERC20/external/properties/ERC20ExternalBasicProperties.sol
+++ b/contracts/ERC20/external/properties/ERC20ExternalBasicProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {CryticERC20ExternalTestBase} from "../util/ERC20ExternalTestBase.sol";

--- a/contracts/ERC20/external/properties/ERC20ExternalBurnableProperties.sol
+++ b/contracts/ERC20/external/properties/ERC20ExternalBurnableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "../util/ERC20ExternalTestBase.sol";

--- a/contracts/ERC20/external/properties/ERC20ExternalIncreaseAllowanceProperties.sol
+++ b/contracts/ERC20/external/properties/ERC20ExternalIncreaseAllowanceProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "../util/ERC20ExternalTestBase.sol";

--- a/contracts/ERC20/external/properties/ERC20ExternalMintableProperties.sol
+++ b/contracts/ERC20/external/properties/ERC20ExternalMintableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "../util/ERC20ExternalTestBase.sol";

--- a/contracts/ERC20/external/properties/ERC20ExternalPausableProperties.sol
+++ b/contracts/ERC20/external/properties/ERC20ExternalPausableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "../util/ERC20ExternalTestBase.sol";

--- a/contracts/ERC20/external/util/ERC20ExternalTestBase.sol
+++ b/contracts/ERC20/external/util/ERC20ExternalTestBase.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "../../../util/PropertiesHelper.sol";

--- a/contracts/ERC20/external/util/ITokenMock.sol
+++ b/contracts/ERC20/external/util/ITokenMock.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "../../../util/IERC20.sol";

--- a/contracts/ERC20/internal/properties/ERC20BasicProperties.sol
+++ b/contracts/ERC20/internal/properties/ERC20BasicProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC20TestBase.sol";

--- a/contracts/ERC20/internal/properties/ERC20BurnableProperties.sol
+++ b/contracts/ERC20/internal/properties/ERC20BurnableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC20TestBase.sol";

--- a/contracts/ERC20/internal/properties/ERC20IncreaseAllowanceProperties.sol
+++ b/contracts/ERC20/internal/properties/ERC20IncreaseAllowanceProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC20TestBase.sol";

--- a/contracts/ERC20/internal/properties/ERC20MintableProperties.sol
+++ b/contracts/ERC20/internal/properties/ERC20MintableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC20TestBase.sol";

--- a/contracts/ERC20/internal/properties/ERC20PausableProperties.sol
+++ b/contracts/ERC20/internal/properties/ERC20PausableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC20TestBase.sol";

--- a/contracts/ERC20/internal/util/ERC20TestBase.sol
+++ b/contracts/ERC20/internal/util/ERC20TestBase.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/ERC4626/ERC4626PropertyTests.sol
+++ b/contracts/ERC4626/ERC4626PropertyTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {TestERC20Token} from "./util/TestERC20Token.sol";

--- a/contracts/ERC4626/properties/FunctionalAccountingProps.sol
+++ b/contracts/ERC4626/properties/FunctionalAccountingProps.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {CryticERC4626PropertyBase} from "../util/ERC4626PropertyTestBase.sol";

--- a/contracts/ERC4626/properties/MustNotRevertProps.sol
+++ b/contracts/ERC4626/properties/MustNotRevertProps.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {CryticERC4626PropertyBase} from "../util/ERC4626PropertyTestBase.sol";

--- a/contracts/ERC4626/properties/RedeemUsingApprovalProps.sol
+++ b/contracts/ERC4626/properties/RedeemUsingApprovalProps.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import {CryticERC4626PropertyBase} from "../util/ERC4626PropertyTestBase.sol";
 import {CryticERC4626VaultProxy} from "./VaultProxy.sol";

--- a/contracts/ERC4626/properties/RoundingProps.sol
+++ b/contracts/ERC4626/properties/RoundingProps.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import {CryticERC4626PropertyBase} from "../util/ERC4626PropertyTestBase.sol";
 import {CryticERC4626VaultProxy} from "./VaultProxy.sol";

--- a/contracts/ERC4626/properties/SecurityProps.sol
+++ b/contracts/ERC4626/properties/SecurityProps.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import {CryticERC4626PropertyBase} from "../util/ERC4626PropertyTestBase.sol";
 

--- a/contracts/ERC4626/properties/SenderIndependentProps.sol
+++ b/contracts/ERC4626/properties/SenderIndependentProps.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import {CryticERC4626PropertyBase} from "../util/ERC4626PropertyTestBase.sol";
 

--- a/contracts/ERC4626/properties/VaultProxy.sol
+++ b/contracts/ERC4626/properties/VaultProxy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import {CryticERC4626PropertyBase} from "../util/ERC4626PropertyTestBase.sol";
 import {CryticIERC4626Internal} from "../util/IERC4626Internal.sol";

--- a/contracts/ERC4626/test/Solmate4626.sol
+++ b/contracts/ERC4626/test/Solmate4626.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";

--- a/contracts/ERC4626/test/rounding/BadConvertToAssetsRounding.sol
+++ b/contracts/ERC4626/test/rounding/BadConvertToAssetsRounding.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";

--- a/contracts/ERC4626/test/rounding/BadConvertToSharesRounding.sol
+++ b/contracts/ERC4626/test/rounding/BadConvertToSharesRounding.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";

--- a/contracts/ERC4626/test/rounding/BadPreviewMintRounding.sol
+++ b/contracts/ERC4626/test/rounding/BadPreviewMintRounding.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";

--- a/contracts/ERC4626/test/rounding/BadPreviewWithdrawRounding.sol
+++ b/contracts/ERC4626/test/rounding/BadPreviewWithdrawRounding.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";

--- a/contracts/ERC4626/test/security/BadShareInflation.sol
+++ b/contracts/ERC4626/test/security/BadShareInflation.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";

--- a/contracts/ERC4626/test/usingApproval/BadAllowanceUpdate.sol
+++ b/contracts/ERC4626/test/usingApproval/BadAllowanceUpdate.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";

--- a/contracts/ERC4626/util/Actor.sol
+++ b/contracts/ERC4626/util/Actor.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {IERC4626} from "../../util/IERC4626.sol";

--- a/contracts/ERC4626/util/ERC4626PropertyTestBase.sol
+++ b/contracts/ERC4626/util/ERC4626PropertyTestBase.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {IERC20} from "../../util/IERC20.sol";

--- a/contracts/ERC4626/util/IERC4626Internal.sol
+++ b/contracts/ERC4626/util/IERC4626Internal.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 /// @notice Developers may optionally implement these interfaces on their Vault contract to increase coverage/enable rounding tests.

--- a/contracts/ERC4626/util/RedemptionProxy.sol
+++ b/contracts/ERC4626/util/RedemptionProxy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {IERC4626} from "../../util/IERC4626.sol";

--- a/contracts/ERC4626/util/TestERC20Token.sol
+++ b/contracts/ERC4626/util/TestERC20Token.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {IERC20} from "../../util/IERC20.sol";

--- a/contracts/ERC721/external/ERC721ExternalPropertyTests.sol
+++ b/contracts/ERC721/external/ERC721ExternalPropertyTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {CryticERC721ExternalTestBase} from "./util/ERC721ExternalTestBase.sol";

--- a/contracts/ERC721/external/properties/ERC721ExternalBasicProperties.sol
+++ b/contracts/ERC721/external/properties/ERC721ExternalBasicProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC721ExternalTestBase.sol";

--- a/contracts/ERC721/external/properties/ERC721ExternalBurnableProperties.sol
+++ b/contracts/ERC721/external/properties/ERC721ExternalBurnableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC721ExternalTestBase.sol";

--- a/contracts/ERC721/external/properties/ERC721ExternalMintableProperties.sol
+++ b/contracts/ERC721/external/properties/ERC721ExternalMintableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC721ExternalTestBase.sol";

--- a/contracts/ERC721/external/test/ERC721Compliant.sol
+++ b/contracts/ERC721/external/test/ERC721Compliant.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/ERC721/external/test/standard/ERC721BasicTests.sol
+++ b/contracts/ERC721/external/test/standard/ERC721BasicTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {CryticERC721ExternalBasicProperties} from "../../properties/ERC721ExternalBasicProperties.sol";

--- a/contracts/ERC721/external/test/standard/ERC721BurnableTests.sol
+++ b/contracts/ERC721/external/test/standard/ERC721BurnableTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {CryticERC721ExternalBurnableProperties} from "../../properties/ERC721ExternalBurnableProperties.sol";

--- a/contracts/ERC721/external/test/standard/ERC721CompliantTests.sol
+++ b/contracts/ERC721/external/test/standard/ERC721CompliantTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {CryticERC721ExternalPropertyTests} from "../../ERC721ExternalPropertyTests.sol";

--- a/contracts/ERC721/external/test/standard/ERC721MintableTests.sol
+++ b/contracts/ERC721/external/test/standard/ERC721MintableTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {CryticERC721ExternalMintableProperties} from "../../properties/ERC721ExternalMintableProperties.sol";

--- a/contracts/ERC721/external/util/ERC721ExternalTestBase.sol
+++ b/contracts/ERC721/external/util/ERC721ExternalTestBase.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "../../../util/PropertiesHelper.sol";

--- a/contracts/ERC721/external/util/MockReceiver.sol
+++ b/contracts/ERC721/external/util/MockReceiver.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";

--- a/contracts/ERC721/internal/ERC721InternalPropertyTests.sol
+++ b/contracts/ERC721/internal/ERC721InternalPropertyTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {CryticERC721TestBase} from "./util/ERC721TestBase.sol";

--- a/contracts/ERC721/internal/properties/ERC721BasicProperties.sol
+++ b/contracts/ERC721/internal/properties/ERC721BasicProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC721TestBase.sol";

--- a/contracts/ERC721/internal/properties/ERC721BurnableProperties.sol
+++ b/contracts/ERC721/internal/properties/ERC721BurnableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC721TestBase.sol";

--- a/contracts/ERC721/internal/properties/ERC721MintableProperties.sol
+++ b/contracts/ERC721/internal/properties/ERC721MintableProperties.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "../util/ERC721TestBase.sol";

--- a/contracts/ERC721/internal/test/standard/ERC721BasicTests.sol
+++ b/contracts/ERC721/internal/test/standard/ERC721BasicTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/ERC721/internal/test/standard/ERC721BurnableTests.sol
+++ b/contracts/ERC721/internal/test/standard/ERC721BurnableTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/ERC721/internal/test/standard/ERC721Compliant.sol
+++ b/contracts/ERC721/internal/test/standard/ERC721Compliant.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/ERC721/internal/test/standard/ERC721MintableTests.sol
+++ b/contracts/ERC721/internal/test/standard/ERC721MintableTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/ERC721/internal/util/ERC721TestBase.sol
+++ b/contracts/ERC721/internal/util/ERC721TestBase.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/contracts/ERC721/internal/util/MockReceiver.sol
+++ b/contracts/ERC721/internal/util/MockReceiver.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";

--- a/contracts/ERC721/util/IERC721Internal.sol
+++ b/contracts/ERC721/util/IERC721Internal.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/Math/ABDKMath64x64/ABDKMath64x64PropertyTests.sol
+++ b/contracts/Math/ABDKMath64x64/ABDKMath64x64PropertyTests.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "./abdk-libraries-solidity/ABDKMath64x64.sol";

--- a/contracts/util/PropertiesConstants.sol
+++ b/contracts/util/PropertiesConstants.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 abstract contract PropertiesConstants {

--- a/contracts/util/PropertiesHelper.sol
+++ b/contracts/util/PropertiesHelper.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 abstract contract PropertiesAsserts {

--- a/tests/ERC20/foundry/src/ExampleToken.sol
+++ b/tests/ERC20/foundry/src/ExampleToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/tests/ERC20/foundry/test/CryticTest.sol
+++ b/tests/ERC20/foundry/test/CryticTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import "properties/ERC20/internal/properties/ERC20BasicProperties.sol";
 import "../src/ExampleToken.sol";

--- a/tests/ERC20/foundry/test/CryticTestExt.sol
+++ b/tests/ERC20/foundry/test/CryticTestExt.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import "../src/ExampleToken.sol";
 import {ITokenMock} from "properties/ERC20/external/util/ITokenMock.sol";

--- a/tests/ERC20/hardhat/contracts/CryticTest.sol
+++ b/tests/ERC20/hardhat/contracts/CryticTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 import "@crytic/properties/contracts/ERC20/internal/properties/ERC20BasicProperties.sol";
 import "./ExampleToken.sol";

--- a/tests/ERC20/hardhat/contracts/CryticTestExt.sol
+++ b/tests/ERC20/hardhat/contracts/CryticTestExt.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import "./ExampleToken.sol";
 import {ITokenMock} from "@crytic/properties/contracts/ERC20/external/util/ITokenMock.sol";

--- a/tests/ERC20/hardhat/contracts/ExampleToken.sol
+++ b/tests/ERC20/hardhat/contracts/ExampleToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/tests/ERC4626/foundry/src/Basic4626Impl.sol
+++ b/tests/ERC4626/foundry/src/Basic4626Impl.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {ERC20} from "solmate/tokens/ERC20.sol";

--- a/tests/ERC4626/foundry/test/CryticTest.sol
+++ b/tests/ERC4626/foundry/test/CryticTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import {CryticERC4626PropertyTests} from "properties/ERC4626/ERC4626PropertyTests.sol";

--- a/tests/ERC4626/hardhat/contracts/Basic4626Impl.sol
+++ b/tests/ERC4626/hardhat/contracts/Basic4626Impl.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {ERC20} from "solmate/src/tokens/ERC20.sol";

--- a/tests/ERC4626/hardhat/contracts/Echidna4626Harness.sol
+++ b/tests/ERC4626/hardhat/contracts/Echidna4626Harness.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
 import {CryticERC4626PropertyTests} from "@crytic/properties/contracts/ERC4626/ERC4626PropertyTests.sol";

--- a/tests/ERC721/foundry/src/ExampleToken.sol
+++ b/tests/ERC721/foundry/src/ExampleToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/tests/ERC721/foundry/test/CryticTest.sol
+++ b/tests/ERC721/foundry/test/CryticTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import "properties/ERC721/internal/properties/ERC721BasicProperties.sol";
 import "../src/ExampleToken.sol";

--- a/tests/ERC721/foundry/test/CryticTestExt.sol
+++ b/tests/ERC721/foundry/test/CryticTestExt.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import "../src/ExampleToken.sol";
 import {IERC721Internal} from "properties/ERC721/util/IERC721Internal.sol";

--- a/tests/ERC721/hardhat/contracts/CryticTest.sol
+++ b/tests/ERC721/hardhat/contracts/CryticTest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import "@crytic/properties/contracts/ERC721/internal/properties/ERC721BasicProperties.sol";
 import "./ExampleToken.sol";

--- a/tests/ERC721/hardhat/contracts/CryticTestExt.sol
+++ b/tests/ERC721/hardhat/contracts/CryticTestExt.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 import "./ExampleToken.sol";
 import {IERC721Internal} from "@crytic/properties/contracts/ERC721/util/IERC721Internal.sol";

--- a/tests/ERC721/hardhat/contracts/ExampleToken.sol
+++ b/tests/ERC721/hardhat/contracts/ExampleToken.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";


### PR DESCRIPTION
context: we try to always treat compiler warnings as errors, to reliably catch some possible issues (such as not assigning to a return variable) as soon as possible, with foundry's `deny-warnings` setting

`solc`, however, reports on a file not having an `SPDX` license identifier as error `1878`, which we have to manually ignore with `ignored_error_codes = [1878]`

This PR takes care of that, adding a SPDX license identifier to every source file missing it. I chose the same license as in the `LICENSE` file, without care for it's legality or consistency, and didn't modify the license identifier of files having one (which includes `Unlicense` and `MIT`)